### PR TITLE
Add default license whitelist for testing

### DIFF
--- a/tests/default_license_whitelist.toml
+++ b/tests/default_license_whitelist.toml
@@ -1,0 +1,10 @@
+[tool.conda-deny]
+safe-licenses = [
+    "Apache-2.0",
+    "Unlicense",
+    "WTFPL",
+    "MIT",
+]
+ignore-packages = [
+    {package="_libgcc_mutex"}
+]


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->
Adding a `default_license_whitelist.toml` file so that the tests in the next refactor PR go through smoothly.

# Changes

<!-- What changes have been performed? -->
