### PR TITLE
Fix pypi flag behavior

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use clap::ArgAction;
 use clap_verbosity_flag::{ErrorLevel, Verbosity};
 
 use clap::Parser;
@@ -41,11 +40,11 @@ pub enum CondaDenyCliConfig {
         environment: Option<Vec<String>>,
 
         /// Check against OSI licenses instead of custom license whitelists.
-        #[arg(short, long, action = ArgAction::SetTrue)]
+        #[arg(short, long)]
         osi: Option<bool>,
 
         /// Ignore when encountering pypi packages instead of failing.
-        #[arg(long, action = ArgAction::SetTrue)]
+        #[arg(long)]
         ignore_pypi: Option<bool>,
     },
     /// List all packages and their licenses in your conda or pixi environment
@@ -133,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_cli_with_check_arguments() {
-        let cli = Cli::try_parse_from(vec!["conda-deny", "check", "--osi"]).unwrap();
+        let cli = Cli::try_parse_from(vec!["conda-deny", "check", "--osi", "true"]).unwrap();
         match cli.command {
             CondaDenyCliConfig::Check { osi, .. } => {
                 assert_eq!(osi, Some(true));

--- a/src/license_whitelist.rs
+++ b/src/license_whitelist.rs
@@ -269,7 +269,7 @@ mod tests {
             .unwrap();
 
         // Assert the result
-        assert_eq!(safe_licenses.len(), 4);
+        assert_eq!(safe_licenses.len(), 5);
         assert!(safe_licenses.iter().any(|e| e.to_string() == "MIT"));
         assert!(safe_licenses.iter().any(|e| e.to_string() == "Apache-2.0"));
         assert_eq!(ignore_packages.len(), 1);


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->
The default behavior by `clap` is to set arguments with `action = ArgAction::SetTrue` to `Some(value)`.
While sensible in some contexts, this breaks some of our checks.

# Changes

<!-- What changes have been performed? -->
The `osi` and `ignore-pypi` flags now need to be specified like so:
`--ignore-pypi false`
