### PR TITLE
Release `0.5.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "conda-deny"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conda-deny"
 description = "A CLI tool to check your project's dependencies for license compliance."
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->

# Changes

<!-- What changes have been performed? -->
Bump `conda-deny` version to `0.5.0`.
