### PR TITLE
ci: Sign releases and limit GHA permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Binary Build
+permissions: read-all
 on:
   push:
     branches:
@@ -28,6 +29,11 @@ jobs:
     name: Build Binary (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     needs: [metadata]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +81,13 @@ jobs:
           ${{ matrix.cross && 'cross' || 'cargo' }} build --release --color always${{ endsWith(matrix.target, 'musl') && ' --no-default-features --features rustls-tls' || '' }} --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/release/conda-deny${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }} conda-deny-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
 
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+        if: needs.metadata.outputs.release == 'true'
+        with:
+          subject-path: conda-deny-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
+
       - name: Upload Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -82,9 +95,44 @@ jobs:
           path: conda-deny-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
           if-no-files-found: error
 
+  hashes:
+    name: Compute hashes
+    needs: [metadata, build]
+    if: needs.metadata.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Download artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: conda-deny-*
+          merge-multiple: true
+      - name: Compute hashes
+        id: hash
+        run: |
+          set -exuo pipefail
+          files=$(ls conda-deny*)
+          echo "hashes=$(sha256sum $files | base64 -w0)" >> "${GITHUB_OUTPUT}"
+
+  provenance:
+    needs: [metadata, hashes]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    if: needs.metadata.outputs.release == 'true'
+    # This cannot be pinned: https://github.com/slsa-framework/slsa-github-generator?tab=readme-ov-file#referencing-slsa-builders-and-generators
+    # https://github.com/slsa-framework/slsa-verifier/issues/12
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.hashes.outputs.hashes }}"
+      upload-assets: false
+
   release:
     name: Create Release
-    needs: [metadata, build]
+    needs: [metadata, build, provenance]
     if: ${{ needs.metadata.outputs.release == 'true' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
@@ -95,14 +143,21 @@ jobs:
         with:
           pattern: conda-deny-*
           merge-multiple: true
+      - name: Download provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.provenance.outputs.provenance-name }}
+          merge-multiple: true
       - name: Push v${{ needs.metadata.outputs.version }} tag
         run: |
           git tag v${{ needs.metadata.outputs.version }}
           git push origin v${{ needs.metadata.outputs.version }}
       - name: Create Release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631  # v2.2.2
         with:
           generate_release_notes: true
           tag_name: v${{ needs.metadata.outputs.version }}
           draft: false
-          files: conda-deny-*
+          files: |
+            ${{ needs.provenance.outputs.provenance-name }}
+            conda-deny-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: Cargo Build, Test & Lint
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,5 @@
 name: coverage
+permissions: read-all
 
 on: 
   push:


### PR DESCRIPTION
This is based on the work in `pixi-pack`.