### PR TITLE
Change boolean flag behavior

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           key: build-${{ matrix.target }}-${{ matrix.cross }}-${{ matrix.os }}
 
@@ -83,7 +83,7 @@ jobs:
 
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         if: needs.metadata.outputs.release == 'true'
         with:
           subject-path: conda-deny-${{ matrix.target }}${{ endsWith(matrix.target, 'windows-msvc') && '.exe' || '' }}
@@ -155,7 +155,7 @@ jobs:
           git tag v${{ needs.metadata.outputs.version }}
           git push origin v${{ needs.metadata.outputs.version }}
       - name: Create Release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631  # v2.2.2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8  # v2.3.2
         with:
           generate_release_notes: true
           tag_name: v${{ needs.metadata.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose
@@ -35,6 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 #v2.7.8
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 #v2.8.0
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D clippy::all -A clippy::too_many_arguments

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -74,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7fd62151d9daff11d4b981415ffb365dcd93f75a # v3.28.15
+        uses: github/codeql-action/upload-sarif@dcc1a6637b570d406bec5125dce2e2157d914359 # v3.28.15
         with:
           sarif_file: results.sarif

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -54,7 +54,7 @@ pub fn bundle<W: Write>(config: CondaDenyBundleConfig, mut out: W) -> Result<()>
                     pkg.location()
                         .as_url()
                         .ok_or_else(|| {
-                            anyhow!(format!("URL for package could not be resolved: {:?}", pkg))
+                            anyhow!(format!("URL for package could not be resolved: {pkg:?}"))
                         })
                         .cloned()
                 },
@@ -73,7 +73,7 @@ pub fn bundle<W: Write>(config: CondaDenyBundleConfig, mut out: W) -> Result<()>
             let mut prefix_records = vec![];
             for prefix in prefix_paths {
                 let recs = PrefixRecord::collect_from_prefix(prefix.as_path())
-                    .with_context(|| format!("Failed to collect from: {:?}", prefix))?;
+                    .with_context(|| format!("Failed to collect from: {prefix:?}"))?;
                 prefix_records.extend(recs);
             }
 
@@ -95,9 +95,9 @@ pub fn bundle<W: Write>(config: CondaDenyBundleConfig, mut out: W) -> Result<()>
     let path = config.directory.unwrap_or(PathBuf::from("bundle"));
     let path = Path::new(&path);
     create_license_file_directory(path, license_files)
-        .with_context(|| format!("Failed to create license file directory: {:?}", path))?;
-    writeln!(out, "License files written to: {:?}", path)
-        .with_context(|| format!("Failed to write license file: {:?}", path))?;
+        .with_context(|| format!("Failed to create license file directory: {path:?}"))?;
+    writeln!(out, "License files written to: {path:?}")
+        .with_context(|| format!("Failed to write license file: {path:?}"))?;
 
     Ok(())
 }
@@ -133,7 +133,7 @@ where
                 files.len(),
                 get_name(item)
             );
-            trace!("License files: {:?}", files);
+            trace!("License files: {files:?}");
 
             let package_name = get_filename(item);
             Ok(files
@@ -157,19 +157,18 @@ where
 fn create_license_file_directory(path: &Path, license_files: Vec<LicenseFile>) -> Result<()> {
     if path.exists() {
         warn!(
-            "Output directory already exists. Removing and creating a new one: {:?}",
-            path
+            "Output directory already exists. Removing and creating a new one: {path:?}"
         );
         std::fs::remove_dir_all(path)
-            .with_context(|| format!("Failed to remove existing directory: {:?}", path))?;
+            .with_context(|| format!("Failed to remove existing directory: {path:?}"))?;
     }
     std::fs::create_dir_all(path)
-        .with_context(|| format!("Failed to create output directory: {:?}", path))?;
+        .with_context(|| format!("Failed to create output directory: {path:?}"))?;
     for license_file in &license_files {
         let package_name = license_file.package_name.to_string();
         let package_path = path.join(package_name);
         std::fs::create_dir_all(&package_path)
-            .with_context(|| format!("Failed to create package directory: {:?}", package_path))?;
+            .with_context(|| format!("Failed to create package directory: {package_path:?}"))?;
 
         let relative_path = Path::new(&license_file.filename)
             .strip_prefix("info/licenses")
@@ -179,10 +178,10 @@ fn create_license_file_directory(path: &Path, license_files: Vec<LicenseFile>) -
 
         let parent = file_path.parent().expect("Parent dir always exists");
         std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create directory for: {:?}", file_path))?;
+            .with_context(|| format!("Failed to create directory for: {file_path:?}"))?;
 
         let mut file = std::fs::File::create(&file_path)
-            .with_context(|| format!("Failed to create license file: {:?}", file_path))?;
+            .with_context(|| format!("Failed to create license file: {file_path:?}"))?;
         file.write_all(
             &license_file
                 .license_text
@@ -190,7 +189,7 @@ fn create_license_file_directory(path: &Path, license_files: Vec<LicenseFile>) -
                 .into_iter()
                 .collect::<Vec<u8>>(),
         )
-        .with_context(|| format!("Failed to write license text to file: {:?}", file_path))?;
+        .with_context(|| format!("Failed to write license text to file: {file_path:?}"))?;
     }
     Ok(())
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -39,7 +39,7 @@ pub fn check<W: Write>(check_config: CondaDenyCheckConfig, mut out: W) -> Result
                 "safe": safe_dependencies,
                 "unsafe": unsafe_dependencies,
             });
-            writeln!(out, "{}", json_output)?;
+            writeln!(out, "{json_output}")?;
         }
         OutputFormat::JsonPretty => {
             let json_output = json!({
@@ -76,8 +76,7 @@ pub fn check<W: Write>(check_config: CondaDenyCheckConfig, mut out: W) -> Result
                 };
                 writer.serialize(&extended_info).with_context(|| {
                     format!(
-                        "Failed to serialize the following LicenseInfo to CSV: {:?}",
-                        extended_info
+                        "Failed to serialize the following LicenseInfo to CSV: {extended_info:?}"
                     )
                 })?;
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,11 +43,11 @@ pub enum CondaDenyCliConfig {
 
         /// Check against OSI licenses instead of custom license allowlists.
         #[arg(long)]
-        osi: Option<bool>,
+        osi: bool,
 
         /// Ignore when encountering pypi packages instead of failing.
         #[arg(long)]
-        ignore_pypi: Option<bool>,
+        ignore_pypi: bool,
 
         /// Output format
         #[arg(short, long)]
@@ -73,7 +73,7 @@ pub enum CondaDenyCliConfig {
 
         /// Ignore when encountering pypi packages instead of failing.
         #[arg(long)]
-        ignore_pypi: Option<bool>,
+        ignore_pypi: bool,
 
         /// Output format
         #[arg(short, long)]
@@ -100,7 +100,7 @@ pub enum CondaDenyCliConfig {
 
         /// Ignore when encountering pypi packages instead of failing.
         #[arg(long)]
-        ignore_pypi: Option<bool>,
+        ignore_pypi: bool,
 
         /// Directory to bundle licenses into
         #[arg(short, long)]
@@ -141,7 +141,7 @@ impl CondaDenyCliConfig {
         }
     }
 
-    pub fn ignore_pypi(&self) -> Option<bool> {
+    pub fn ignore_pypi(&self) -> bool {
         match self {
             CondaDenyCliConfig::Check { ignore_pypi, .. } => *ignore_pypi,
             CondaDenyCliConfig::List { ignore_pypi, .. } => *ignore_pypi,
@@ -182,10 +182,10 @@ mod tests {
 
     #[test]
     fn test_cli_with_check_arguments() {
-        let cli = Cli::try_parse_from(vec!["conda-deny", "check", "--osi", "true"]).unwrap();
+        let cli = Cli::try_parse_from(vec!["conda-deny", "check", "--osi"]).unwrap();
         match cli.command {
             CondaDenyCliConfig::Check { osi, .. } => {
-                assert_eq!(osi, Some(true));
+                assert!(osi);
             }
             _ => panic!("Expected check subcommand with --include-safe"),
         }

--- a/src/conda_deny_config.rs
+++ b/src/conda_deny_config.rs
@@ -72,7 +72,7 @@ impl CondaDenyTomlConfig {
         file.read_to_string(&mut contents)?;
 
         let config: CondaDenyTomlConfig = toml::from_str(&contents)
-            .with_context(|| format!("Failed to parse TOML from the file: {:?}", filepath))?;
+            .with_context(|| format!("Failed to parse TOML from the file: {filepath:?}"))?;
 
         debug!("Loaded config from file: {:?}", filepath.clone());
 

--- a/src/conda_meta_entry.rs
+++ b/src/conda_meta_entry.rs
@@ -23,10 +23,10 @@ pub struct CondaMetaEntry {
 impl CondaMetaEntry {
     pub fn from_filepath(filepath: &str) -> Result<Self> {
         let contents = Self::read_file(filepath)
-            .with_context(|| format!("Failed to read file: {}", filepath))?;
+            .with_context(|| format!("Failed to read file: {filepath}"))?;
 
         let v: Value = serde_json::from_str(&contents)
-            .with_context(|| format!("Failed to parse JSON from file: {}", filepath))?;
+            .with_context(|| format!("Failed to parse JSON from file: {filepath}"))?;
 
         let license_str = v["license"].as_str().unwrap_or_default();
         let license = match parse_expression(license_str) {
@@ -49,15 +49,15 @@ impl CondaMetaEntry {
         let path = Path::new(filepath);
 
         if !path.exists() {
-            anyhow::bail!("Error: The file {} does not exist.", filepath);
+            anyhow::bail!("Error: The file {filepath} does not exist.");
         }
 
-        let mut file = File::open(filepath)
-            .with_context(|| format!("Failed to open the file: {}", filepath))?;
+        let mut file =
+            File::open(filepath).with_context(|| format!("Failed to open the file: {filepath}"))?;
 
         let mut contents = String::new();
         file.read_to_string(&mut contents)
-            .with_context(|| format!("Failed to read the file: {}", filepath))?;
+            .with_context(|| format!("Failed to read the file: {filepath}"))?;
 
         Ok(contents)
     }

--- a/src/expression_utils.rs
+++ b/src/expression_utils.rs
@@ -30,7 +30,7 @@ pub fn parse_expression(expression_str: &str) -> Result<Expression> {
     };
 
     Expression::parse_mode(expression_str, parse_mode)
-        .with_context(|| format!("Failed to parse expression: '{}'", expression_str))
+        .with_context(|| format!("Failed to parse expression: '{expression_str}'"))
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub fn get_config_options(
     // else, try to load pixi.toml, then pyproject.toml and if nothing helps, use empty config
     let toml_config = if let Some(config_path) = config {
         CondaDenyTomlConfig::from_path(config_path.clone())
-            .with_context(|| format!("Failed to parse config file {:?}", config_path))?
+            .with_context(|| format!("Failed to parse config file {config_path:?}"))?
     } else {
         match CondaDenyTomlConfig::from_path("pixi.toml".into())
             .with_context(|| "Failed to parse config file pixi.toml")
@@ -203,8 +203,7 @@ pub fn get_config_options(
             }
             Err(e) => {
                 debug!(
-                    "Error parsing config file: pixi.toml: {}. Attempting to use pyproject.toml instead...",
-                    e
+                    "Error parsing config file: pixi.toml: {e}. Attempting to use pyproject.toml instead..."
                 );
                 match CondaDenyTomlConfig::from_path("pyproject.toml".into())
                     .context(e)
@@ -213,8 +212,7 @@ pub fn get_config_options(
                     Ok(config) => config,
                     Err(e) => {
                         debug!(
-                            "Error parsing config file: pyproject.toml: {}. Using empty config instead...",
-                            e
+                            "Error parsing config file: pyproject.toml: {e}. Using empty config instead..."
                         );
                         CondaDenyTomlConfig::empty()
                     }
@@ -223,7 +221,7 @@ pub fn get_config_options(
         }
     };
 
-    debug!("Parsed TOML config: {:?}", toml_config);
+    debug!("Parsed TOML config: {toml_config:?}");
 
     let output_format = cli_config.output().unwrap_or_default();
     let lockfile_or_prefix = get_lockfile_or_prefix(&cli_config, &toml_config)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ fn get_lockfile_or_prefix(
             environments: cli_config.environment(),
             lockfiles: resolve_glob_patterns(&lockfile_patterns)?,
             platforms: cli_config.platform(),
-            ignore_pypi: cli_config.ignore_pypi().unwrap_or(IGNORE_PYPI_DEFAULT),
+            ignore_pypi: cli_config.ignore_pypi() || IGNORE_PYPI_DEFAULT,
         };
         Ok(LockfileOrPrefix::Lockfile(lockfile_spec))
     } else {
@@ -173,10 +173,8 @@ fn get_lockfile_or_prefix(
         let environments = cli_config
             .environment()
             .or(toml_config.get_environment_spec());
-        let ignore_pypi = cli_config
-            .ignore_pypi()
-            .or(toml_config.get_ignore_pypi())
-            .unwrap_or(IGNORE_PYPI_DEFAULT);
+        let ignore_pypi = cli_config.ignore_pypi()
+            || toml_config.get_ignore_pypi().unwrap_or(IGNORE_PYPI_DEFAULT);
         Ok(LockfileOrPrefix::Lockfile(LockfileSpec {
             lockfiles,
             platforms,
@@ -232,7 +230,7 @@ pub fn get_config_options(
 
     let config = match cli_config {
         CondaDenyCliConfig::Check { osi, .. } => {
-            let osi = osi.or(toml_config.get_osi()).unwrap_or(false);
+            let osi = osi || toml_config.get_osi().unwrap_or(false);
 
             let (safe_licenses, ignore_packages) =
                 get_license_information_from_toml_config(&toml_config)?;

--- a/src/license_allowlist.rs
+++ b/src/license_allowlist.rs
@@ -41,10 +41,7 @@ pub fn is_package_ignored(
     package_version: &str,
 ) -> Result<bool> {
     let parsed_package_version = Version::from_str(package_version).with_context(|| {
-        format!(
-            "Error parsing package version: {} for package: {}",
-            package_version, package_name
-        )
+        format!("Error parsing package version: {package_version} for package: {package_name}")
     })?;
 
     for ignore_package in ignore_packages {
@@ -55,8 +52,7 @@ pub fn is_package_ignored(
                         VersionSpec::from_str(version_req_str, ParseStrictness::Strict)
                             .with_context(|| {
                                 format!(
-                                    "Error parsing version requirement: {} for package: {}",
-                                    version_req_str, package_name
+                                    "Error parsing version requirement: {version_req_str} for package: {package_name}"
                                 )
                             })?;
 
@@ -79,17 +75,17 @@ pub fn license_config_from_toml_str(
     toml_file: &str,
 ) -> Result<(Vec<Expression>, Vec<IgnorePackage>)> {
     let config_content = fs::read_to_string(toml_file)
-        .with_context(|| format!("Failed to read TOML file: {}", toml_file))?;
+        .with_context(|| format!("Failed to read TOML file: {toml_file}"))?;
 
     let config: LicenseAllowlistConfig = toml::from_str(&config_content)
-        .with_context(|| format!("Failed to parse TOML content from file: {}", toml_file))?;
+        .with_context(|| format!("Failed to parse TOML content from file: {toml_file}"))?;
 
     let mut expressions = Vec::new();
 
     if let Some(safe_licenses) = config.tool.conda_deny.safe_licenses {
         for license in safe_licenses {
             let expr = parse_expression(&license)
-                .with_context(|| format!("Failed to parse license expression: {}", license))?;
+                .with_context(|| format!("Failed to parse license expression: {license}"))?;
             expressions.push(expr);
         }
     }
@@ -116,7 +112,7 @@ impl ReadRemoteConfig for RealRemoteConfigReader {
         if let Some(token) = get_bearer_token() {
             headers.insert(
                 AUTHORIZATION,
-                HeaderValue::from_str(&format!("Bearer {}", token))
+                HeaderValue::from_str(&format!("Bearer {token}"))
                     .with_context(|| "Invalid Header value for AUTHORIZATION")?,
             );
         }
@@ -166,15 +162,12 @@ pub fn fetch_safe_licenses(
     })?;
 
     let config: LicenseAllowlistConfig = toml::from_str(&config_str).with_context(|| {
-        format!(
-            "Failed to parse license allowlist to TOML for allowlist URL: {}",
-            url
-        )
+        format!("Failed to parse license allowlist to TOML for allowlist URL: {url}")
     })?;
     let mut expressions = Vec::new();
     for license in config.tool.conda_deny.safe_licenses.unwrap_or_default() {
         let expr = parse_expression(&license)
-            .with_context(|| format!("Failed to parse license expression: {}", license))?;
+            .with_context(|| format!("Failed to parse license expression: {license}"))?;
         expressions.push(expr);
     }
     let ignore_packages = config.tool.conda_deny.ignore_packages.unwrap_or_default();
@@ -199,10 +192,7 @@ pub fn build_license_allowlist(
                 }
                 Err(e) => {
                     return Err(e).with_context(|| {
-                        format!(
-                            "Failed to fetch safe licenses from URL: {}",
-                            license_allowlist_path
-                        )
+                        format!("Failed to fetch safe licenses from URL: {license_allowlist_path}")
                     });
                 }
             }
@@ -214,10 +204,7 @@ pub fn build_license_allowlist(
                 }
                 Err(e) => {
                     return Err(e).with_context(|| {
-                        format!(
-                            "Failed to parse TOML file at path: {}",
-                            license_allowlist_path
-                        )
+                        format!("Failed to parse TOML file at path: {license_allowlist_path}")
                     });
                 }
             }

--- a/src/license_info.rs
+++ b/src/license_info.rs
@@ -161,8 +161,7 @@ impl LicenseInfos {
             let conda_meta_entries =
                 CondaMetaEntries::from_dir(&conda_meta_path).with_context(|| {
                     format!(
-                        "Failed to parse conda meta entries from conda-meta: {:?}",
-                        conda_meta_path
+                        "Failed to parse conda meta entries from conda-meta: {conda_meta_path:?}"
                     )
                 })?;
 
@@ -266,7 +265,7 @@ fn serialize_expression<S>(expr: &Expression, serializer: S) -> Result<S::Ok, S:
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(&format!("{:?}", expr))
+    serializer.serialize_str(&format!("{expr:?}"))
 }
 
 #[cfg(test)]

--- a/src/list.rs
+++ b/src/list.rs
@@ -13,7 +13,7 @@ pub fn list<W: Write>(config: CondaDenyListConfig, mut out: W) -> Result<()> {
             for license_info in &license_infos.license_infos {
                 output.push_str(&license_info.pretty_print());
             }
-            writeln!(out, "{}", output)?;
+            writeln!(out, "{output}")?;
         }
         OutputFormat::Json => {
             serde_json::to_writer(&mut out, &license_infos)?;
@@ -27,8 +27,7 @@ pub fn list<W: Write>(config: CondaDenyListConfig, mut out: W) -> Result<()> {
             for license_info in &license_infos.license_infos {
                 writer.serialize(license_info).with_context(|| {
                     format!(
-                        "Failed to serialize the following license info: {:?}",
-                        license_info
+                        "Failed to serialize the following license info: {license_info:?}"
                     )
                 })?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,11 @@ fn main() -> Result<()> {
         .filter_level(cli.verbose.log_level_filter())
         .init();
 
-    debug!("Parsed CLI config: {:?}", cli);
+    debug!("Parsed CLI config: {cli:?}");
 
     let config = get_config_options(cli.config, cli.command)?;
 
-    info!("Parsed config: {:?}", config);
+    info!("Parsed config: {config:?}");
 
     let stdout = io::stdout();
 

--- a/src/pixi_lock.rs
+++ b/src/pixi_lock.rs
@@ -20,7 +20,7 @@ pub fn get_conda_packages_for_pixi_lock(
     ignore_pypi: bool,
 ) -> Result<Vec<CondaPackageData>> {
     let lock_file = LockFile::from_path(pixi_lock_path)
-        .with_context(|| format!("Failed to read pixi.lock file: {:?}", pixi_lock_path))?;
+        .with_context(|| format!("Failed to read pixi.lock file: {pixi_lock_path:?}"))?;
     let environment_spec = environment_spec
         .clone()
         .unwrap_or_else(|| _get_environment_names(&lock_file));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -114,7 +114,7 @@ fn test_default_use_case(#[case] subcommand: &str, #[case] test_name: &str) {
 
     use log::debug;
 
-    let path_string = format!("tests/{}", test_name);
+    let path_string = format!("tests/{test_name}");
     let test_dir = Path::new(path_string.as_str());
 
     let output = Command::cargo_bin("conda-deny")
@@ -126,7 +126,7 @@ fn test_default_use_case(#[case] subcommand: &str, #[case] test_name: &str) {
         .expect("Failed to execute command");
 
     let stdout = str::from_utf8(&output.stdout).unwrap();
-    debug!("Output: {}", stdout);
+    debug!("Output: {stdout}");
     if subcommand == "check" {
         assert!(stdout.contains("There were \u{1b}[32m247\u{1b}[0m safe licenses and \u{1b}[31m301\u{1b}[0m unsafe licenses."), "{stdout}");
         output.assert().failure();
@@ -458,10 +458,10 @@ fn test_pypi_ignore_error(
 ) {
     let result = check(check_config, &mut out);
     if let Err(e) = &result {
-        println!("Actual error: {}", e);
+        println!("Actual error: {e}");
     }
     assert!(result.is_err());
-    assert!(format!("{:?}", result).contains("Pypi packages are not supported: beautifulsoup4"));
+    assert!(format!("{result:?}").contains("Pypi packages are not supported: beautifulsoup4"));
     assert_eq!(out, b"");
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -22,7 +22,7 @@ fn list_config(
     #[default(None)] prefix: Option<Vec<PathBuf>>,
     #[default(None)] platform: Option<Vec<Platform>>,
     #[default(None)] environment: Option<Vec<String>>,
-    #[default(None)] ignore_pypi: Option<bool>,
+    #[default(false)] ignore_pypi: bool,
     #[default(Some(OutputFormat::Default))] output: Option<OutputFormat>,
 ) -> CondaDenyListConfig {
     let cli = CondaDenyCliConfig::List {
@@ -49,7 +49,7 @@ fn bundle_config(
     #[default(None)] prefix: Option<Vec<PathBuf>>,
     #[default(None)] platform: Option<Vec<Platform>>,
     #[default(None)] environment: Option<Vec<String>>,
-    #[default(None)] ignore_pypi: Option<bool>,
+    #[default(false)] ignore_pypi: bool,
     #[default(None)] directory: Option<PathBuf>,
 ) -> CondaDenyBundleConfig {
     let cli = CondaDenyCliConfig::Bundle {
@@ -76,8 +76,8 @@ fn check_config(
     #[default(None)] prefix: Option<Vec<PathBuf>>,
     #[default(None)] platform: Option<Vec<Platform>>,
     #[default(None)] environment: Option<Vec<String>>,
-    #[default(None)] osi: Option<bool>,
-    #[default(None)] ignore_pypi: Option<bool>,
+    #[default(false)] osi: bool,
+    #[default(false)] ignore_pypi: bool,
     #[default(Some(OutputFormat::Default))] output: Option<OutputFormat>,
 ) -> CondaDenyCheckConfig {
     let cli = CondaDenyCliConfig::Check {
@@ -153,12 +153,12 @@ fn test_lockfile_pattern(#[case] subcommand: &str) {
         None,
         None,
         None,
-        None,
-        None,
+        false,
+        false,
         None,
     );
 
-    let list_config = list_config(Some(config), None, None, None, None, None, None);
+    let list_config = list_config(Some(config), None, None, None, None, false, None);
 
     if subcommand == "check" {
         let result = check(check_config, &mut out);
@@ -201,8 +201,8 @@ license-allowlist = "https://raw.githubusercontent.com/Quantco/conda-deny/refs/h
         None,
         None,
         None,
-        None,
-        None,
+        false,
+        false,
         None,
     );
 
@@ -249,8 +249,8 @@ fn test_multiple_allowlists_check() {
         None,
         None,
         None,
-        None,
-        None,
+        false,
+        false,
         None,
     );
 
@@ -281,7 +281,7 @@ environment = "lint""#;
     let mut out = out();
     // Inject the temporary file's path into check_config
     let temp_path = Some(temp_pixi_toml.path().to_path_buf());
-    let check_config = check_config(temp_path, None, None, None, None, None, None, None);
+    let check_config = check_config(temp_path, None, None, None, None, false, false, None);
 
     let result = check(check_config, &mut out);
     let output = String::from_utf8(out).unwrap();
@@ -314,8 +314,8 @@ safe-licenses = ["BSD-3-Clause"]"#;
         None,
         None,
         None,
-        None,
-        None,
+        false,
+        false,
         None,
     );
 
@@ -342,7 +342,7 @@ fn test_osi_check(
         // ENVIRONMENT
         None,
         // OSI FLAG
-        Some(true)
+        true
     )]
     check_config: CondaDenyCheckConfig,
     mut out: Vec<u8>,
@@ -418,9 +418,9 @@ fn test_pypi_ignore_check(
         // ENVIRONMENT
         None,
         // OSI FLAG
-        None,
+        false,
         // IGNORE PYPI
-        Some(true)
+        true
     )]
     check_config: CondaDenyCheckConfig,
     mut out: Vec<u8>,
@@ -449,9 +449,9 @@ fn test_pypi_ignore_error(
         // ENVIRONMENT
         None,
         // OSI FLAG
-        None,
+        false,
         // IGNORE PYPI
-        Some(false)
+        false
     )]
     check_config: CondaDenyCheckConfig,
     mut out: Vec<u8>,
@@ -481,7 +481,7 @@ fn test_bundle_prefix() {
         // ENVIRONMENT
         None,
         // IGNORE PYPI
-        None,
+        false,
         // DIRECTORY
         Some(temp_dir.path().join(Path::new("test_bundle"))),
     );
@@ -529,7 +529,7 @@ fn test_bundle_lockfile() {
         // ENVIRONMENT
         None,
         // IGNORE PYPI
-        None,
+        false,
         // DIRECTORY
         Some(temp_dir.path().join(Path::new("test_bundle"))),
     );


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->
Currently, `conda-deny` requires an explicit value to be passed to the two boolean flags `--osi` and `--ignore-pypi`.
E.g. 
```bash
$ conda-deny check --osi true
```

While in line with the `.toml` configuration of the flags, this is not intuitive from a user perspective and unnecessarily complicated.

# Changes

<!-- What changes have been performed? -->
This PR adjusts the CLI to use boolean flags in the following format:
```bash
$ conda-deny check --osi # This sets the osi flag to true.
$ conda-deny check # This implicitly sets the osi flag to false.
```