### PR TITLE
Add completion command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +431,7 @@ dependencies = [
  "async-trait",
  "clap",
  "clap-verbosity-flag",
+ "clap_complete",
  "colored",
  "csv",
  "env_logger",
@@ -3150,7 +3160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -1470,6 +1473,15 @@ checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "conda-deny"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "conda-deny"
-version = "0.5.9"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conda-deny"
 description = "A CLI tool to check your project's dependencies for license compliance."
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ opt-level = "s"
 
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
+clap_complete = "4.6"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 toml = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ opt-level = "s"
 
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }
-clap_complete = "4.6"
+clap_complete = { version = "4.6", features = ["unstable-dynamic"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 toml = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conda-deny"
 description = "A CLI tool to check your project's dependencies for license compliance."
-version = "0.5.9"
+version = "0.5.8"
 edition = "2021"
 
 [features]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,6 +120,7 @@ pub enum CondaDenyCliConfig {
     /// Generate shell completions
     Completion {
         /// Shell to generate completions for
+        #[arg(long)]
         shell: Shell,
     },
 }
@@ -215,7 +216,7 @@ mod tests {
 
     #[test]
     fn test_cli_with_completion_arguments() {
-        let cli = Cli::try_parse_from(vec!["conda-deny", "completion", "bash"]).unwrap();
+        let cli = Cli::try_parse_from(vec!["conda-deny", "completion", "--shell", "bash"]).unwrap();
         match cli.command {
             CondaDenyCliConfig::Completion { shell } => {
                 assert_eq!(shell, Shell::Bash);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,13 +2,18 @@ use std::path::PathBuf;
 
 use clap_verbosity_flag::{ErrorLevel, Verbosity};
 
-use clap::Parser;
+use clap::{Parser, ValueHint};
+use clap_complete::Shell;
 use rattler_conda_types::Platform;
 
 use crate::OutputFormat;
 
 #[derive(Parser, Debug)]
-#[command(name = "conda-deny", about = "Check and list licenses of pixi and conda environments", version = env!("CARGO_PKG_VERSION"))]
+#[command(
+    name = "conda-deny",
+    about = "Check and list licenses of pixi and conda environments",
+    version = env!("CARGO_PKG_VERSION")
+)]
 pub struct Cli {
     #[command(flatten)]
     pub verbose: Verbosity<ErrorLevel>,
@@ -17,7 +22,7 @@ pub struct Cli {
     pub command: CondaDenyCliConfig,
 
     /// Path to the conda-deny config file
-    #[arg(short, long, global = true)]
+    #[arg(short, long, global = true, value_hint = ValueHint::FilePath)]
     pub config: Option<PathBuf>,
 }
 
@@ -26,11 +31,16 @@ pub enum CondaDenyCliConfig {
     /// Check licenses of pixi or conda environment against a allowlist
     Check {
         /// Path to the pixi lockfile(s), can be glob patterns
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = ValueHint::AnyPath)]
         lockfile: Option<Vec<String>>,
 
         /// Path to the conda prefix(es)
-        #[arg(long, global = true, conflicts_with_all = ["platform", "environment", "lockfile"])]
+        #[arg(
+            long,
+            global = true,
+            conflicts_with_all = ["platform", "environment", "lockfile"],
+            value_hint = ValueHint::DirPath
+        )]
         prefix: Option<Vec<PathBuf>>,
 
         /// Platform(s) to check
@@ -56,11 +66,11 @@ pub enum CondaDenyCliConfig {
     /// List all packages and their licenses in your conda or pixi environment
     List {
         /// Path to the pixi lockfile(s)
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = ValueHint::AnyPath)]
         lockfile: Option<Vec<String>>,
 
         /// Path to the conda prefix(es)
-        #[arg(long, global = true)]
+        #[arg(long, global = true, value_hint = ValueHint::DirPath)]
         prefix: Option<Vec<PathBuf>>,
 
         /// Platform(s) to list
@@ -83,11 +93,11 @@ pub enum CondaDenyCliConfig {
     /// Bundle all dependency licenses in a directory
     Bundle {
         /// Path to the pixi lockfile(s)
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = ValueHint::AnyPath)]
         lockfile: Option<Vec<String>>,
 
         /// Path to the conda prefix(es)
-        #[arg(long, global = true)]
+        #[arg(long, global = true, value_hint = ValueHint::DirPath)]
         prefix: Option<Vec<PathBuf>>,
 
         /// Platform(s) to bundle
@@ -103,8 +113,14 @@ pub enum CondaDenyCliConfig {
         ignore_pypi: Option<bool>,
 
         /// Directory to bundle licenses into
-        #[arg(short, long)]
+        #[arg(short, long, value_hint = ValueHint::DirPath)]
         directory: Option<PathBuf>,
+    },
+
+    /// Generate shell completions
+    Completion {
+        /// Shell to generate completions for
+        shell: Shell,
     },
 }
 
@@ -114,6 +130,7 @@ impl CondaDenyCliConfig {
             CondaDenyCliConfig::Check { lockfile, .. } => lockfile.clone(),
             CondaDenyCliConfig::List { lockfile, .. } => lockfile.clone(),
             CondaDenyCliConfig::Bundle { lockfile, .. } => lockfile.clone(),
+            CondaDenyCliConfig::Completion { .. } => None,
         }
     }
 
@@ -122,6 +139,7 @@ impl CondaDenyCliConfig {
             CondaDenyCliConfig::Check { prefix, .. } => prefix.clone(),
             CondaDenyCliConfig::List { prefix, .. } => prefix.clone(),
             CondaDenyCliConfig::Bundle { prefix, .. } => prefix.clone(),
+            CondaDenyCliConfig::Completion { .. } => None,
         }
     }
 
@@ -130,6 +148,7 @@ impl CondaDenyCliConfig {
             CondaDenyCliConfig::Check { platform, .. } => platform.clone(),
             CondaDenyCliConfig::List { platform, .. } => platform.clone(),
             CondaDenyCliConfig::Bundle { platform, .. } => platform.clone(),
+            CondaDenyCliConfig::Completion { .. } => None,
         }
     }
 
@@ -138,6 +157,7 @@ impl CondaDenyCliConfig {
             CondaDenyCliConfig::Check { environment, .. } => environment.clone(),
             CondaDenyCliConfig::List { environment, .. } => environment.clone(),
             CondaDenyCliConfig::Bundle { environment, .. } => environment.clone(),
+            CondaDenyCliConfig::Completion { .. } => None,
         }
     }
 
@@ -146,6 +166,7 @@ impl CondaDenyCliConfig {
             CondaDenyCliConfig::Check { ignore_pypi, .. } => *ignore_pypi,
             CondaDenyCliConfig::List { ignore_pypi, .. } => *ignore_pypi,
             CondaDenyCliConfig::Bundle { ignore_pypi, .. } => *ignore_pypi,
+            CondaDenyCliConfig::Completion { .. } => None,
         }
     }
 
@@ -154,6 +175,7 @@ impl CondaDenyCliConfig {
             CondaDenyCliConfig::Check { output, .. } => *output,
             CondaDenyCliConfig::List { output, .. } => *output,
             CondaDenyCliConfig::Bundle { .. } => None,
+            CondaDenyCliConfig::Completion { .. } => None,
         }
     }
 }
@@ -188,6 +210,17 @@ mod tests {
                 assert_eq!(osi, Some(true));
             }
             _ => panic!("Expected check subcommand with --include-safe"),
+        }
+    }
+
+    #[test]
+    fn test_cli_with_completion_arguments() {
+        let cli = Cli::try_parse_from(vec!["conda-deny", "completion", "bash"]).unwrap();
+        match cli.command {
+            CondaDenyCliConfig::Completion { shell } => {
+                assert_eq!(shell, Shell::Bash);
+            }
+            _ => panic!("Expected completion subcommand"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,12 +156,6 @@ pub fn get_config_options(
     config: Option<PathBuf>,
     cli_config: CondaDenyCliConfig,
 ) -> Result<CondaDenyConfig> {
-    if matches!(cli_config, CondaDenyCliConfig::Completion { .. }) {
-        return Err(anyhow::anyhow!(
-            "completion command does not use project configuration"
-        ));
-    }
-
     // if config provided, use config
     // else, try to load pixi.toml, then pyproject.toml and if nothing helps, use empty config
     let toml_config = if let Some(config_path) = config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,12 @@ pub fn get_config_options(
     config: Option<PathBuf>,
     cli_config: CondaDenyCliConfig,
 ) -> Result<CondaDenyConfig> {
+    if matches!(cli_config, CondaDenyCliConfig::Completion { .. }) {
+        return Err(anyhow::anyhow!(
+            "completion command does not use project configuration"
+        ));
+    }
+
     // if config provided, use config
     // else, try to load pixi.toml, then pyproject.toml and if nothing helps, use empty config
     let toml_config = if let Some(config_path) = config {
@@ -232,6 +238,7 @@ pub fn get_config_options(
                 directory,
             })
         }
+        CondaDenyCliConfig::Completion { .. } => unreachable!(),
     };
 
     Ok(config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ fn print_completions(shell: clap_complete::Shell, stdout: &mut dyn Write) -> Res
     let mut command = Cli::command();
 
     if shell == clap_complete::Shell::Bash {
+        // clap_complete currently generates mismatched Bash command-state names for
+        // hyphenated command names, which breaks subcommand completion.
         command = command.name("conda_deny");
         let mut completions = Vec::new();
         clap_complete::generate(shell, &mut command, "conda_deny", &mut completions);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,10 @@ use std::{
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
+use clap_complete::{
+    env::{Bash, Elvish, EnvCompleter, Fish, Powershell, Zsh},
+    CompleteEnv,
+};
 use conda_deny::bundle::bundle;
 use conda_deny::check::check;
 use conda_deny::cli::{Cli, CondaDenyCliConfig};
@@ -14,28 +18,34 @@ use conda_deny::CondaDenyConfig;
 use log::{debug, info};
 
 fn print_completions(shell: clap_complete::Shell, stdout: &mut dyn Write) -> Result<()> {
-    let mut command = Cli::command();
+    let command = Cli::command();
+    // We are using the (unstable) Rust-Native completion engine.
+    // It addresses some bugs that would otherwise need to be fixed here
+    // (see https://github.com/clap-rs/clap/issues/3166)
+    let completer: &dyn EnvCompleter = match shell {
+        clap_complete::Shell::Bash => &Bash,
+        clap_complete::Shell::Elvish => &Elvish,
+        clap_complete::Shell::Fish => &Fish,
+        clap_complete::Shell::PowerShell => &Powershell,
+        clap_complete::Shell::Zsh => &Zsh,
+        _ => unreachable!("clap_complete::Shell is non-exhaustive"),
+    };
 
-    if shell == clap_complete::Shell::Bash {
-        // clap_complete currently generates mismatched Bash command-state names for
-        // hyphenated command names, which breaks subcommand completion.
-        command = command.name("conda_deny");
-        let mut completions = Vec::new();
-        clap_complete::generate(shell, &mut command, "conda_deny", &mut completions);
-        let completions = String::from_utf8(completions)?;
-        write!(
-            stdout,
-            "{}",
-            completions.replace(" conda_deny\n", " conda-deny\n")
-        )?;
-    } else {
-        clap_complete::generate(shell, &mut command, "conda-deny", stdout);
-    }
-
+    completer.write_registration(
+        "COMPLETE",
+        command.get_name(),
+        "conda-deny",
+        "conda-deny",
+        stdout,
+    )?;
     Ok(())
 }
 
 fn run() -> Result<()> {
+    CompleteEnv::with_factory(Cli::command)
+        .bin("conda-deny")
+        .complete();
+
     let cli = Cli::parse();
 
     env_logger::Builder::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,37 @@
-use std::{io, process::ExitCode};
+use std::{
+    io::{self, Write},
+    process::ExitCode,
+};
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use conda_deny::bundle::bundle;
 use conda_deny::check::check;
-use conda_deny::cli::Cli;
+use conda_deny::cli::{Cli, CondaDenyCliConfig};
 use conda_deny::get_config_options;
 use conda_deny::list::list;
 use conda_deny::CondaDenyConfig;
 use log::{debug, info};
+
+fn print_completions(shell: clap_complete::Shell, stdout: &mut dyn Write) -> Result<()> {
+    let mut command = Cli::command();
+
+    if shell == clap_complete::Shell::Bash {
+        command = command.name("conda_deny");
+        let mut completions = Vec::new();
+        clap_complete::generate(shell, &mut command, "conda_deny", &mut completions);
+        let completions = String::from_utf8(completions)?;
+        write!(
+            stdout,
+            "{}",
+            completions.replace(" conda_deny\n", " conda-deny\n")
+        )?;
+    } else {
+        clap_complete::generate(shell, &mut command, "conda-deny", stdout);
+    }
+
+    Ok(())
+}
 
 fn run() -> Result<()> {
     let cli = Cli::parse();
@@ -18,6 +41,10 @@ fn run() -> Result<()> {
         .init();
 
     debug!("Parsed CLI config: {cli:?}");
+
+    if let CondaDenyCliConfig::Completion { shell } = cli.command {
+        return print_completions(shell, &mut io::stdout());
+    }
 
     let config = get_config_options(cli.config, cli.command)?;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -141,7 +141,9 @@ fn test_default_use_case(#[case] subcommand: &str, #[case] test_name: &str) {
 
 #[test]
 fn test_completion_bash() {
-    let output = Command::new(assert_cmd::cargo::cargo_bin!("conda-deny"))
+    let binary = assert_cmd::cargo::cargo_bin!("conda-deny");
+
+    let output = Command::new(&binary)
         .args(["completion", "--shell", "bash"])
         .output()
         .expect("Failed to execute command");
@@ -149,11 +151,23 @@ fn test_completion_bash() {
     assert!(output.status.success());
 
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("complete -F _conda_deny"));
-    assert!(stdout.contains("conda-deny"));
-    assert!(stdout.contains("conda_deny__subcmd__check"));
-    assert!(!stdout.contains("conda__subcmd__deny"));
+    assert!(stdout.contains("complete -o nospace"));
+    assert!(stdout.contains("-F _clap_complete_conda_deny conda-deny"));
+    assert!(stdout.contains("COMPLETE=\"bash\""));
+
+    let output = Command::new(binary)
+        .env("COMPLETE", "bash")
+        .env("_CLAP_COMPLETE_INDEX", "2")
+        .env("_CLAP_IFS", "\n")
+        .args(["--", "conda-deny", "check", "--"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("--lockfile"));
+    assert!(stdout.contains("--output"));
 }
 
 #[rstest]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -142,7 +142,7 @@ fn test_default_use_case(#[case] subcommand: &str, #[case] test_name: &str) {
 #[test]
 fn test_completion_bash() {
     let output = Command::new(assert_cmd::cargo::cargo_bin!("conda-deny"))
-        .args(["completion", "bash"])
+        .args(["completion", "--shell", "bash"])
         .output()
         .expect("Failed to execute command");
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -139,6 +139,22 @@ fn test_default_use_case(#[case] subcommand: &str, #[case] test_name: &str) {
     }
 }
 
+#[test]
+fn test_completion_bash() {
+    let output = Command::new(assert_cmd::cargo::cargo_bin!("conda-deny"))
+        .args(["completion", "bash"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("complete -F _conda_deny"));
+    assert!(stdout.contains("conda-deny"));
+    assert!(stdout.contains("conda_deny__subcmd__check"));
+    assert!(stdout.contains("--lockfile"));
+}
+
 #[rstest]
 #[case("check")]
 #[case("list")]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -152,6 +152,7 @@ fn test_completion_bash() {
     assert!(stdout.contains("complete -F _conda_deny"));
     assert!(stdout.contains("conda-deny"));
     assert!(stdout.contains("conda_deny__subcmd__check"));
+    assert!(!stdout.contains("conda__subcmd__deny"));
     assert!(stdout.contains("--lockfile"));
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -143,7 +143,7 @@ fn test_default_use_case(#[case] subcommand: &str, #[case] test_name: &str) {
 fn test_completion_bash() {
     let binary = assert_cmd::cargo::cargo_bin!("conda-deny");
 
-    let output = Command::new(&binary)
+    let output = Command::new(binary)
         .args(["completion", "--shell", "bash"])
         .output()
         .expect("Failed to execute command");


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->
Before this PR, `conda-deny` did not support completions.

# Changes

<!-- What changes have been performed? -->
This PR adds a `completion` command to `conda-deny` which allows for completion generation for the most common shells (`bash`, `elvish`, `fish`, `powershell`, `zsh`) via `clap_complete`.
