### PR TITLE
Support source packages in lockfile v7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tests_private/
 
 # conda-deny bundle default output directory
 bundle/
+*.pending-snap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "conda-deny"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-id"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e"
+dependencies = [
+ "astral-reqwest-middleware",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +134,21 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "astral-reqwest-middleware"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 2.0.12",
+ "tower-service",
 ]
 
 [[package]]
@@ -207,6 +236,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,9 +280,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake2"
@@ -294,10 +345,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -379,6 +431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -419,6 +490,7 @@ version = "0.5.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "astral-reqwest-middleware",
  "async-trait",
  "clap",
  "clap-verbosity-flag",
@@ -438,7 +510,6 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "reqwest-middleware",
  "rstest",
  "serde",
  "serde_json",
@@ -661,6 +732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,9 +823,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file_url"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e546758dbcde9d10c0d3bd8b83adb535b23fa81121cf4dc5c3e7b5907cc8eb8"
+checksum = "f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -768,6 +845,12 @@ dependencies = [
  "libredox",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -839,6 +922,12 @@ checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1174,12 +1263,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1517,6 +1604,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.12",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,10 +1664,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2071,6 +2209,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.2",
  "lru-slab",
@@ -2152,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.46.0"
+version = "0.46.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add942503b3cf8c6f797707762bcf9206709ce1bc001b974860b0313fd002ced"
+checksum = "6018a34d7edb8a6b97c971ba935e59d217a0986376d14f4d515fb238b28bdf02"
 dependencies = [
  "ahash",
  "chrono",
@@ -2195,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.2.4"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbab3541bf7e471550c91b70dad8edf392ffa9f57c6b0de4bbe6dd2c6c0d53d4"
+checksum = "3c44304c9353802e910fac1dbdf6e16df44c341d07b1850bc1fd8b03912cbaab"
 dependencies = [
  "blake2",
  "digest",
@@ -2205,6 +2344,7 @@ dependencies = [
  "hex",
  "md-5",
  "serde",
+ "serde-untagged",
  "serde_bytes",
  "serde_with",
  "sha2",
@@ -2214,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.29.0"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85ccd8874d949e22666b311acc978726ec3db4580d7cb1405508a17bcbf8faa"
+checksum = "a0c0fe27729fd9081d25eb1a23d94f49f23ee93a75d59bac0ae3e304bda04aae"
 dependencies = [
  "ahash",
  "chrono",
@@ -2243,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.13"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677367cf07dd4ca5b863a91cf060feea246f3b23d50af9e9fadf980db760d270"
+checksum = "9d44a87a904057524e32dc8beeb50197016cec467d487bce9d64e044adbcaeb5"
 dependencies = [
  "quote",
  "syn",
@@ -2253,11 +2393,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.26.11"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07edac2226913e2afbbb3e499fdcf2dab9b5ee6d19bcab8fdd3cde49c98bc1e3"
+checksum = "19984b40494bdbaf785525ba36fdb1fa487fe44a36b4214851af4428c69ecf27"
 dependencies = [
+ "ambient-id",
  "anyhow",
+ "astral-reqwest-middleware",
  "async-once-cell",
  "async-trait",
  "base64",
@@ -2266,7 +2408,6 @@ dependencies = [
  "http",
  "itertools 0.14.0",
  "reqwest",
- "reqwest-middleware",
  "retry-policies",
  "serde",
  "serde_json",
@@ -2278,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090fa9f0e13494294bb02bbcf6f7356c97b4483dd80b5838436aeaafada1f58e"
+checksum = "eefa295dc7b49aa0b67d125400561d2b45b754c66c0f7a19e8fc375b1056bfa9"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -2312,20 +2453,20 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.14"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222837efcfa358dbb6107a741bb73bfdae75dae19d5e7eb9c869d84a9edd0a9c"
+checksum = "2d1893dff3da09d778304797291869b17287e35a785cd8bc58fb9cd4760ef51b"
 dependencies = [
+ "astral-reqwest-middleware",
  "reqwest",
- "reqwest-middleware",
  "url",
 ]
 
 [[package]]
 name = "rattler_solve"
-version = "6.0.1"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240d0458274dfc53a32260cbf4b5a30d63c86531bfbe85fc0026c31431a6709d"
+checksum = "eef2142527283596cad4f0b89f4fa0c87a2e20831bf8ef51422d72c9fc6bc316"
 dependencies = [
  "chrono",
  "humantime",
@@ -2435,9 +2576,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2459,8 +2600,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2477,22 +2618,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.0",
-]
-
-[[package]]
-name = "reqwest-middleware"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
-dependencies = [
- "anyhow",
- "async-trait",
- "http",
- "reqwest",
- "serde",
- "thiserror 1.0.69",
- "tower-service",
 ]
 
 [[package]]
@@ -2581,8 +2706,8 @@ version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2598,7 +2723,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2612,11 +2737,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2704,6 +2857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.0",
@@ -2731,9 +2893,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2986,6 +3148,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3150,7 +3322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3419,13 +3591,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3717,48 +3894,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3766,22 +3927,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3810,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3835,9 +3996,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3854,19 +4015,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
+name = "webpki-root-certs"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.0",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conda-deny"
 description = "A CLI tool to check your project's dependencies for license compliance."
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,14 @@ edition = "2021"
 default = ["native-tls"]
 native-tls = [
   "reqwest/native-tls",
-  "reqwest/native-tls-alpn",
   "rattler_networking/native-tls",
   "rattler_package_streaming/native-tls",
 ]
 rustls-tls = [
-  "reqwest/rustls-tls",
-  "reqwest/rustls-tls-native-roots",
-  "rattler_networking/rustls-tls",
-  "reqwest-middleware/rustls-tls",
-  "rattler_package_streaming/rustls-tls",
+  "reqwest/rustls",
+  "rattler_networking/rustls",
+  "reqwest-middleware/rustls",
+  "rattler_package_streaming/rustls",
 ]
 
 # See https://doc.rust-lang.org/cargo/reference/profiles.html
@@ -35,7 +33,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 toml = "1.1.2"
 tokio = { version = "1.52.1", features = ["full"] }
-reqwest = { version = "0.12.28", default-features = false, features = [
+reqwest = { version = "0.13.3", default-features = false, features = [
   "http2",
   "blocking",
   "stream",
@@ -45,18 +43,18 @@ regex = "1.12.3"
 spdx = "0.13.4"
 colored = "3.1.1"
 async-trait = "0.1.89"
-rattler_conda_types = "0.46.0"
-rattler_lock = "0.29.0"
+rattler_conda_types = "0.46.4"
+rattler_lock = "0.30.3"
 anyhow = "1.0.102"
 clap-verbosity-flag = "3.0.4"
 env_logger = "0.11.10"
 log = "0.4.29"
 csv = "1.4.0"
-rattler_package_streaming = { version = "0.25.0", default-features = false }
+rattler_package_streaming = { version = "0.26.2", default-features = false }
 indicatif = "0.18.4"
 rayon = "1.12.0"
-rattler_networking = { version = "0.26.9", default-features = false }
-reqwest-middleware = { version = "0.4.1", default-features = false }
+rattler_networking = { version = "0.27.2", default-features = false }
+reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5.1", default-features = false }
 tar = "0.4.45"
 futures = "0.3.32"
 glob = "0.3.3"

--- a/src/check.rs
+++ b/src/check.rs
@@ -53,10 +53,10 @@ pub fn check<W: Write>(check_config: CondaDenyCheckConfig, mut out: W) -> Result
             #[derive(Debug, Clone, Serialize)]
             struct LicenseInfoWithSafety {
                 package_name: String,
-                version: String,
+                version: Option<String>,
                 license: LicenseState,
                 platform: Option<String>,
-                build: String,
+                build: Option<String>,
                 safe: bool,
             }
 

--- a/src/license_info.rs
+++ b/src/license_info.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use rattler_conda_types::prefix_record::PrefixRecord;
 use rattler_conda_types::PackageRecord;
-use rattler_lock::{CondaPackageData, PartialSourceMetadata};
+use rattler_lock::{CondaPackageData, CondaSourceData, SourceIdentifier};
 use rayon::prelude::*;
 use serde::Serialize;
 use spdx::Expression;
@@ -24,6 +24,8 @@ pub struct LicenseInfo {
     pub license: LicenseState,
     pub platform: Option<String>,
     pub build: Option<String>,
+    #[serde(skip_serializing)]
+    pub source_identifier: Option<String>,
 }
 
 impl LicenseInfo {
@@ -34,17 +36,21 @@ impl LicenseInfo {
             license: license_state_from_optional_str(package_record.license.as_deref()),
             platform: Some(package_record.subdir),
             build: Some(package_record.build),
+            source_identifier: None,
         }
     }
 
-    pub fn from_partial_source_metadata(metadata: &PartialSourceMetadata) -> Self {
-        LicenseInfo {
+    pub fn from_partial_source(source_data: &CondaSourceData) -> Option<Self> {
+        let metadata = source_data.metadata.as_partial()?;
+
+        Some(LicenseInfo {
             package_name: metadata.name.as_source().to_string(),
             version: None,
             license: license_state_from_optional_str(metadata.license.as_deref()),
             platform: None,
             build: None,
-        }
+            source_identifier: Some(SourceIdentifier::from_source_data(source_data).to_string()),
+        })
     }
 
     pub fn pretty_print(&self) -> String {
@@ -62,6 +68,25 @@ impl LicenseInfo {
         let version = self.version.as_deref().unwrap_or("unknown-source");
         let build = self.build.as_deref().unwrap_or("unknown-source");
         let platform = self.platform.as_deref().unwrap_or("unknown-source");
+
+        if let Some(source_identifier) = &self.source_identifier {
+            return if let Some(comment) = comment {
+                format!(
+                    "{} ({}): {} {}\n",
+                    source_identifier.blue(),
+                    "source".bright_purple(),
+                    license_str.yellow(),
+                    comment.bright_black(),
+                )
+            } else {
+                format!(
+                    "{} ({}): {}\n",
+                    source_identifier.blue(),
+                    "source".bright_purple(),
+                    license_str.yellow(),
+                )
+            };
+        }
 
         if let Some(comment) = comment {
             format!(
@@ -94,6 +119,7 @@ impl PartialEq for LicenseInfo {
             && self.version == other.version
             && self.build == other.build
             && self.platform == other.platform
+            && self.source_identifier == other.source_identifier
     }
 }
 
@@ -112,6 +138,7 @@ impl Ord for LicenseInfo {
             .then_with(|| self.version.cmp(&other.version))
             .then_with(|| self.build.cmp(&other.build))
             .then_with(|| self.platform.cmp(&other.platform))
+            .then_with(|| self.source_identifier.cmp(&other.source_identifier))
     }
 }
 
@@ -177,17 +204,21 @@ impl LicenseInfos {
                     continue;
                 }
 
-                let Some(metadata) = package
-                    .as_source()
-                    .and_then(|source| source.metadata.as_partial())
-                else {
+                let Some(source) = package.as_source() else {
                     return Err(anyhow::anyhow!(
                         "Package record missing in lockfile for {package_name}. \
                          Add a name-only entry for this package to ignore-packages to ignore it."
                     ));
                 };
 
-                license_infos.insert(LicenseInfo::from_partial_source_metadata(metadata));
+                let Some(license_info) = LicenseInfo::from_partial_source(source) else {
+                    return Err(anyhow::anyhow!(
+                        "Package record missing in lockfile for {package_name}. \
+                         Add a name-only entry for this package to ignore-packages to ignore it."
+                    ));
+                };
+
+                license_infos.insert(license_info);
             }
         }
 
@@ -333,6 +364,7 @@ mod tests {
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
             build: Some("py_0".to_string()),
+            source_identifier: None,
         };
         let safe_license_info = LicenseInfo {
             package_name: "test".to_string(),
@@ -340,6 +372,7 @@ mod tests {
             license: LicenseState::Valid(Expression::parse("MIT").unwrap()),
             platform: Some("linux-64".to_string()),
             build: Some("py_0".to_string()),
+            source_identifier: None,
         };
 
         let unsafe_license_infos = LicenseInfos {
@@ -381,6 +414,7 @@ mod tests {
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
             build: Some("py_0".to_string()),
+            source_identifier: None,
         };
         let license_info2 = LicenseInfo {
             package_name: "test2".to_string(),
@@ -388,6 +422,7 @@ mod tests {
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
             build: Some("py_0".to_string()),
+            source_identifier: None,
         };
 
         let mut license_infos = LicenseInfos {
@@ -408,6 +443,7 @@ mod tests {
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
             build: Some("py_0".to_string()),
+            source_identifier: None,
         };
         let license_info2 = LicenseInfo {
             package_name: "test".to_string(),
@@ -415,6 +451,7 @@ mod tests {
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
             build: Some("py_0".to_string()),
+            source_identifier: None,
         };
 
         let mut license_infos = LicenseInfos {

--- a/src/license_info.rs
+++ b/src/license_info.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use rattler_conda_types::prefix_record::PrefixRecord;
 use rattler_conda_types::PackageRecord;
-use rattler_lock::CondaPackageData;
+use rattler_lock::{CondaPackageData, PartialSourceMetadata};
 use rayon::prelude::*;
 use serde::Serialize;
 use spdx::Expression;
@@ -28,21 +28,22 @@ pub struct LicenseInfo {
 
 impl LicenseInfo {
     pub fn from_package_record(package_record: PackageRecord) -> Self {
-        let license_str = match &package_record.license {
-            Some(license) => license.clone(),
-            None => "None".to_string(),
-        };
-        let license_for_package = match parse_expression(&license_str) {
-            Ok(parsed_license) => LicenseState::Valid(parsed_license),
-            Err(_) => LicenseState::Invalid(license_str.to_owned()),
-        };
-
         LicenseInfo {
             package_name: package_record.name.as_source().to_string(),
             version: package_record.version.version().to_string(),
-            license: license_for_package,
+            license: license_state_from_optional_str(package_record.license.as_deref()),
             platform: Some(package_record.subdir),
             build: package_record.build,
+        }
+    }
+
+    pub fn from_partial_source_metadata(metadata: &PartialSourceMetadata) -> Self {
+        LicenseInfo {
+            package_name: metadata.name.as_source().to_string(),
+            version: "unknown".to_string(),
+            license: license_state_from_optional_str(metadata.license.as_deref()),
+            platform: None,
+            build: "source".to_string(),
         }
     }
 
@@ -150,21 +151,31 @@ impl LicenseInfos {
         let mut license_infos = BTreeSet::new();
         for package in conda_packages {
             let package_name = package.name().as_source();
-            let Some(record) = package.record().cloned() else {
+
+            if let Some(record) = package.record().cloned() {
+                let package_version = record.version.version().to_string();
+                if is_package_ignored(ignore_packages, package_name, &package_version)? {
+                    continue;
+                }
+
+                license_infos.insert(LicenseInfo::from_package_record(record));
+            } else {
                 if is_package_ignored_by_name_only(ignore_packages, package_name) {
                     continue;
                 }
 
-                return Err(anyhow::anyhow!(
-                    "Package record missing in lockfile for {package_name}. \
-                     Add a name-only entry for this package to ignore-packages to ignore it."
-                ));
-            };
-            let package_version = record.version.version().to_string();
-            if is_package_ignored(ignore_packages, package_name, &package_version)? {
-                continue;
+                let Some(metadata) = package
+                    .as_source()
+                    .and_then(|source| source.metadata.as_partial())
+                else {
+                    return Err(anyhow::anyhow!(
+                        "Package record missing in lockfile for {package_name}. \
+                         Add a name-only entry for this package to ignore-packages to ignore it."
+                    ));
+                };
+
+                license_infos.insert(LicenseInfo::from_partial_source_metadata(metadata));
             }
-            license_infos.insert(LicenseInfo::from_package_record(record));
         }
 
         Ok(LicenseInfos {
@@ -273,6 +284,14 @@ pub enum LicenseState {
     #[serde(serialize_with = "serialize_expression")]
     Valid(Expression),
     Invalid(String),
+}
+
+fn license_state_from_optional_str(license: Option<&str>) -> LicenseState {
+    let license_str = license.unwrap_or("None");
+    match parse_expression(license_str) {
+        Ok(parsed_license) => LicenseState::Valid(parsed_license),
+        Err(_) => LicenseState::Invalid(license_str.to_owned()),
+    }
 }
 
 fn serialize_expression<S>(expr: &Expression, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/license_info.rs
+++ b/src/license_info.rs
@@ -20,30 +20,30 @@ use crate::{
 #[derive(Debug, Clone, Serialize)]
 pub struct LicenseInfo {
     pub package_name: String,
-    pub version: String,
+    pub version: Option<String>,
     pub license: LicenseState,
     pub platform: Option<String>,
-    pub build: String,
+    pub build: Option<String>,
 }
 
 impl LicenseInfo {
     pub fn from_package_record(package_record: PackageRecord) -> Self {
         LicenseInfo {
             package_name: package_record.name.as_source().to_string(),
-            version: package_record.version.version().to_string(),
+            version: Some(package_record.version.version().to_string()),
             license: license_state_from_optional_str(package_record.license.as_deref()),
             platform: Some(package_record.subdir),
-            build: package_record.build,
+            build: Some(package_record.build),
         }
     }
 
     pub fn from_partial_source_metadata(metadata: &PartialSourceMetadata) -> Self {
         LicenseInfo {
             package_name: metadata.name.as_source().to_string(),
-            version: "unknown".to_string(),
+            version: None,
             license: license_state_from_optional_str(metadata.license.as_deref()),
             platform: None,
-            build: "source".to_string(),
+            build: None,
         }
     }
 
@@ -51,25 +51,38 @@ impl LicenseInfo {
         let license_str = match &self.license {
             LicenseState::Valid(license) => license.to_string(),
             LicenseState::Invalid(license) => license.to_string(),
+            LicenseState::NoLicense => "no license".to_string(),
         };
 
-        let recognized = match &self.license {
-            LicenseState::Valid(_) => "",
-            LicenseState::Invalid(_) => "(Non-SPDX)",
+        let comment = match &self.license {
+            LicenseState::Valid(_) => None,
+            LicenseState::Invalid(_) => Some("(Non-SPDX)"),
+            LicenseState::NoLicense => None,
         };
-        format!(
-            "{} {}-{} ({}): {} {}\n",
-            &self.package_name.blue(),
-            &self.version.cyan(),
-            &self.build.bright_cyan().italic(),
-            &self
-                .platform
-                .as_ref()
-                .unwrap_or(&"Unknown".to_string())
-                .bright_purple(),
-            license_str.yellow(),
-            recognized.bright_black(),
-        )
+        let version = self.version.as_deref().unwrap_or("unknown-source");
+        let build = self.build.as_deref().unwrap_or("unknown-source");
+        let platform = self.platform.as_deref().unwrap_or("unknown-source");
+
+        if let Some(comment) = comment {
+            format!(
+                "{} {}-{} ({}): {} {}\n",
+                &self.package_name.blue(),
+                &version.cyan(),
+                &build.bright_cyan().italic(),
+                &platform.bright_purple(),
+                license_str.yellow(),
+                comment.bright_black(),
+            )
+        } else {
+            format!(
+                "{} {}-{} ({}): {}\n",
+                &self.package_name.blue(),
+                &version.cyan(),
+                &build.bright_cyan().italic(),
+                &platform.bright_purple(),
+                license_str.yellow(),
+            )
+        }
     }
 }
 
@@ -237,7 +250,7 @@ impl LicenseInfos {
                         unsafe_dependencies.push(license_info.clone());
                     }
                 }
-                LicenseState::Invalid(_) => {
+                LicenseState::Invalid(_) | LicenseState::NoLicense => {
                     unsafe_dependencies.push(license_info.clone());
                 }
             }
@@ -268,7 +281,7 @@ impl LicenseInfos {
                         unsafe_dependencies.push(license_info.clone());
                     }
                 }
-                LicenseState::Invalid(_) => {
+                LicenseState::Invalid(_) | LicenseState::NoLicense => {
                     unsafe_dependencies.push(license_info.clone());
                 }
             }
@@ -284,13 +297,16 @@ pub enum LicenseState {
     #[serde(serialize_with = "serialize_expression")]
     Valid(Expression),
     Invalid(String),
+    NoLicense,
 }
 
 fn license_state_from_optional_str(license: Option<&str>) -> LicenseState {
-    let license_str = license.unwrap_or("None");
-    match parse_expression(license_str) {
+    let Some(license) = license else {
+        return LicenseState::NoLicense;
+    };
+    match parse_expression(license) {
         Ok(parsed_license) => LicenseState::Valid(parsed_license),
-        Err(_) => LicenseState::Invalid(license_str.to_owned()),
+        Err(_) => LicenseState::Invalid(license.to_owned()),
     }
 }
 
@@ -313,17 +329,17 @@ mod tests {
         // Create license infos without unsafe dependencies
         let unsafe_license_info = LicenseInfo {
             package_name: "test".to_string(),
-            version: "0.1.0".to_string(),
+            version: Some("0.1.0".to_string()),
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
-            build: "py_0".to_string(),
+            build: Some("py_0".to_string()),
         };
         let safe_license_info = LicenseInfo {
             package_name: "test".to_string(),
-            version: "0.1.0".to_string(),
+            version: Some("0.1.0".to_string()),
             license: LicenseState::Valid(Expression::parse("MIT").unwrap()),
             platform: Some("linux-64".to_string()),
-            build: "py_0".to_string(),
+            build: Some("py_0".to_string()),
         };
 
         let unsafe_license_infos = LicenseInfos {
@@ -361,17 +377,17 @@ mod tests {
     fn test_sort_license_infos() {
         let license_info1 = LicenseInfo {
             package_name: "test".to_string(),
-            version: "0.1.0".to_string(),
+            version: Some("0.1.0".to_string()),
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
-            build: "py_0".to_string(),
+            build: Some("py_0".to_string()),
         };
         let license_info2 = LicenseInfo {
             package_name: "test2".to_string(),
-            version: "0.1.0".to_string(),
+            version: Some("0.1.0".to_string()),
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
-            build: "py_0".to_string(),
+            build: Some("py_0".to_string()),
         };
 
         let mut license_infos = LicenseInfos {
@@ -388,17 +404,17 @@ mod tests {
     fn test_dedub_license_infos() {
         let license_info1 = LicenseInfo {
             package_name: "test".to_string(),
-            version: "0.1.0".to_string(),
+            version: Some("0.1.0".to_string()),
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
-            build: "py_0".to_string(),
+            build: Some("py_0".to_string()),
         };
         let license_info2 = LicenseInfo {
             package_name: "test".to_string(),
-            version: "0.1.0".to_string(),
+            version: Some("0.1.0".to_string()),
             license: LicenseState::Invalid("Invalid-MIT".to_string()),
             platform: Some("linux-64".to_string()),
-            build: "py_0".to_string(),
+            build: Some("py_0".to_string()),
         };
 
         let mut license_infos = LicenseInfos {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15,6 +15,29 @@ use std::process::Command;
 use tempfile::NamedTempFile;
 use walkdir::WalkDir;
 
+const SOURCE_PACKAGE_VARIANTS_LOCKFILE: &str = r#"version: 7
+platforms:
+- name: linux-64
+- name: linux-aarch64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda_source: my-package[6652ddb3] @ .
+      linux-aarch64:
+      - conda_source: my-package[949d3bf9] @ .
+packages:
+- conda_source: my-package[6652ddb3] @ .
+  variants:
+    target_platform: noarch
+- conda_source: my-package[949d3bf9] @ .
+  variants:
+    target_platform: noarch
+  license: MIT
+"#;
+
 #[fixture]
 #[once]
 fn colored_control() {
@@ -494,31 +517,9 @@ fn test_pixi_build_list(
 #[rstest]
 fn test_list_source_package_variants_with_license(mut out: Vec<u8>, _colored_control: ()) {
     let mut temp_lockfile = NamedTempFile::new().unwrap();
-    let lockfile_content = r#"version: 7
-platforms:
-- name: linux-64
-- name: linux-aarch64
-environments:
-  default:
-    channels:
-    - url: https://conda.anaconda.org/conda-forge/
-    packages:
-      linux-64:
-      - conda_source: my-package[6652ddb3] @ .
-      linux-aarch64:
-      - conda_source: my-package[949d3bf9] @ .
-packages:
-- conda_source: my-package[6652ddb3] @ .
-  variants:
-    target_platform: noarch
-- conda_source: my-package[949d3bf9] @ .
-  variants:
-    target_platform: noarch
-  license: MIT
-"#;
     temp_lockfile
         .as_file_mut()
-        .write_all(lockfile_content.as_bytes())
+        .write_all(SOURCE_PACKAGE_VARIANTS_LOCKFILE.as_bytes())
         .unwrap();
 
     let list_config = list_config(
@@ -534,7 +535,52 @@ packages:
     let stripped_output = String::from_utf8(strip_ansi_escapes::strip(out)).unwrap();
 
     assert!(result.is_ok(), "{result:?}");
-    insta::assert_snapshot!(stripped_output, @"my-package unknown-source-unknown-source (unknown-source): MIT");
+    insta::assert_snapshot!(stripped_output, @r"
+my-package[6652ddb3] @ . (source): no license
+my-package[949d3bf9] @ . (source): MIT
+");
+}
+
+#[rstest]
+fn test_check_source_package_variants_with_license(mut out: Vec<u8>, _colored_control: ()) {
+    let mut temp_lockfile = NamedTempFile::new().unwrap();
+    temp_lockfile
+        .as_file_mut()
+        .write_all(SOURCE_PACKAGE_VARIANTS_LOCKFILE.as_bytes())
+        .unwrap();
+
+    let mut temp_config_file = NamedTempFile::new().unwrap();
+    let config_content = r#"[tool.conda-deny]
+safe-licenses = ["MIT"]
+"#;
+    temp_config_file
+        .as_file_mut()
+        .write_all(config_content.as_bytes())
+        .unwrap();
+
+    let check_config = check_config(
+        Some(temp_config_file.path().to_path_buf()),
+        Some(vec![temp_lockfile.path().display().to_string()]),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let result = check(check_config, &mut out);
+    let stripped_output = String::from_utf8(strip_ansi_escapes::strip(out)).unwrap();
+
+    assert!(result.is_err());
+    insta::assert_snapshot!(stripped_output, @r"
+
+❌ The following dependencies are unsafe:
+
+my-package[6652ddb3] @ . (source): no license
+
+❌ Unsafe licenses found! ❌
+There were 1 safe licenses and 1 unsafe licenses.
+");
 }
 
 #[rstest]
@@ -678,8 +724,9 @@ fn test_check_checks_source_package_without_record(
 
     assert!(result.is_err());
     assert!(output.contains("my-partial-pkg"));
-    assert!(output.contains("unknown-source"));
-    assert!(output.contains("None"));
+    assert!(output.contains("my-partial-pkg[abcd1234] @ my-partial-pkg"));
+    assert!(output.contains("(source)"));
+    assert!(output.contains("no license"));
 }
 
 #[rstest]
@@ -724,8 +771,9 @@ fn test_list_shows_source_package_without_record(
 
     assert!(result.is_ok(), "{result:?}");
     assert!(output.contains("my-partial-pkg"));
-    assert!(output.contains("unknown-source"));
-    assert!(output.contains("None"));
+    assert!(output.contains("my-partial-pkg[abcd1234] @ my-partial-pkg"));
+    assert!(output.contains("(source)"));
+    assert!(output.contains("no license"));
 }
 
 #[rstest]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -621,16 +621,19 @@ ignore-packages = [{ package = "my-partial-pkg" }]"#;
 #[rstest]
 #[case("tests/test_ignored_source_package/pixi.toml")]
 #[case("tests/test_ignored_source_package/pixi_ignore_version.toml")]
-fn test_check_errors_on_source_package_without_record(
+fn test_check_checks_source_package_without_record(
     #[case] _config_path: &str,
     #[with(Some(PathBuf::from(_config_path)))] check_config: CondaDenyCheckConfig,
     mut out: Vec<u8>,
     _colored_control: (),
 ) {
     let result = check(check_config, &mut out);
-    let error = format!("{result:?}");
+    let output = String::from_utf8(strip_ansi_escapes::strip(out)).unwrap();
 
-    assert!(error.contains("Package record missing in lockfile for my-partial-pkg"));
+    assert!(result.is_err());
+    assert!(output.contains("my-partial-pkg"));
+    assert!(output.contains("unknown-source"));
+    assert!(output.contains("None"));
 }
 
 #[rstest]
@@ -664,16 +667,19 @@ ignore-packages = [{ package = "my-partial-pkg" }]"#;
 #[rstest]
 #[case("tests/test_ignored_source_package/pixi.toml")]
 #[case("tests/test_ignored_source_package/pixi_ignore_version.toml")]
-fn test_list_errors_on_source_package_without_record(
+fn test_list_shows_source_package_without_record(
     #[case] _config_path: &str,
     #[with(Some(PathBuf::from(_config_path)))] list_config: CondaDenyListConfig,
     mut out: Vec<u8>,
     _colored_control: (),
 ) {
     let result = list(list_config, &mut out);
-    let error = format!("{result:?}");
+    let output = String::from_utf8(strip_ansi_escapes::strip(out)).unwrap();
 
-    assert!(error.contains("Package record missing in lockfile for my-partial-pkg"));
+    assert!(result.is_ok(), "{result:?}");
+    assert!(output.contains("my-partial-pkg"));
+    assert!(output.contains("unknown-source"));
+    assert!(output.contains("None"));
 }
 
 #[rstest]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -492,6 +492,52 @@ fn test_pixi_build_list(
 }
 
 #[rstest]
+fn test_list_source_package_variants_with_license(mut out: Vec<u8>, _colored_control: ()) {
+    let mut temp_lockfile = NamedTempFile::new().unwrap();
+    let lockfile_content = r#"version: 7
+platforms:
+- name: linux-64
+- name: linux-aarch64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda_source: my-package[6652ddb3] @ .
+      linux-aarch64:
+      - conda_source: my-package[949d3bf9] @ .
+packages:
+- conda_source: my-package[6652ddb3] @ .
+  variants:
+    target_platform: noarch
+- conda_source: my-package[949d3bf9] @ .
+  variants:
+    target_platform: noarch
+  license: MIT
+"#;
+    temp_lockfile
+        .as_file_mut()
+        .write_all(lockfile_content.as_bytes())
+        .unwrap();
+
+    let list_config = list_config(
+        None,
+        Some(vec![temp_lockfile.path().display().to_string()]),
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let result = list(list_config, &mut out);
+    let stripped_output = String::from_utf8(strip_ansi_escapes::strip(out)).unwrap();
+
+    assert!(result.is_ok(), "{result:?}");
+    insta::assert_snapshot!(stripped_output, @"my-package unknown-source-unknown-source (unknown-source): MIT");
+}
+
+#[rstest]
 fn test_bundle_prefix() {
     let mut out = out();
     let temp_dir = tempfile::tempdir().unwrap();

--- a/tests/snapshots/integration_tests__check.snap
+++ b/tests/snapshots/integration_tests__check.snap
@@ -5,27 +5,27 @@ expression: output
 
 ❌ The following dependencies are unsafe:
 
-_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause 
-binutils_impl_linux-64 2.43-h4bf12b8_4 (linux-64): GPL-3.0-only 
-ca-certificates 2025.4.26-hbd8a1cb_0 (noarch): ISC 
-gcc_impl_linux-64 13.3.0-h1e990d8_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-k9s 0.50.4-h643be8f_0 (linux-64): Apache-2.0 
+_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause
+binutils_impl_linux-64 2.43-h4bf12b8_4 (linux-64): GPL-3.0-only
+ca-certificates 2025.4.26-hbd8a1cb_0 (noarch): ISC
+gcc_impl_linux-64 13.3.0-h1e990d8_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+k9s 0.50.4-h643be8f_0 (linux-64): Apache-2.0
 kernel-headers_linux-64 3.10.0-he073ed8_18 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-ld_impl_linux-64 2.43-h712a8e2_4 (linux-64): GPL-3.0-only 
-libgcc 15.1.0-h767d61c_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-64 13.3.0-hc03c837_102 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 15.1.0-h69a702a_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 15.1.0-h767d61c_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 13.3.0-he8ea267_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx 15.1.0-h8f9b012_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libzlib 1.3.1-hb9d3cd8_2 (linux-64): Zlib 
-openssl 3.5.0-h7b32b05_1 (linux-64): Apache-2.0 
-pkg-config 0.29.2-h4bc722e_1009 (linux-64): GPL-2.0-or-later 
-rust 1.77.2-h70c747d_1 (linux-64): MIT 
-rust-std-x86_64-unknown-linux-gnu 1.77.2-h2c6d0dc_1 (noarch): MIT 
+ld_impl_linux-64 2.43-h712a8e2_4 (linux-64): GPL-3.0-only
+libgcc 15.1.0-h767d61c_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-64 13.3.0-hc03c837_102 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 15.1.0-h69a702a_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 15.1.0-h767d61c_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 13.3.0-he8ea267_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx 15.1.0-h8f9b012_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libzlib 1.3.1-hb9d3cd8_2 (linux-64): Zlib
+openssl 3.5.0-h7b32b05_1 (linux-64): Apache-2.0
+pkg-config 0.29.2-h4bc722e_1009 (linux-64): GPL-2.0-or-later
+rust 1.77.2-h70c747d_1 (linux-64): MIT
+rust-std-x86_64-unknown-linux-gnu 1.77.2-h2c6d0dc_1 (noarch): MIT
 sysroot_linux-64 2.17-h0157908_18 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-tzdata 2025b-h78e105d_0 (noarch): LicenseRef-Public-Domain 
-vhs 0.7.2-ha770c72_0 (linux-64): MIT 
+tzdata 2025b-h78e105d_0 (noarch): LicenseRef-Public-Domain
+vhs 0.7.2-ha770c72_0 (linux-64): MIT
 
 ❌ Unsafe licenses found! ❌
 There were 0 safe licenses and 21 unsafe licenses.

--- a/tests/snapshots/integration_tests__check_test_default_use_case.snap
+++ b/tests/snapshots/integration_tests__check_test_default_use_case.snap
@@ -5,244 +5,244 @@ expression: stdout
 
 ❌ The following dependencies are unsafe:
 
-_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause 
-_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause 
+_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause
+_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause
 _sysroot_linux-aarch64_curr_repodata_hack 4-h57d6b7b_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only 
-binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only 
-binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only 
-binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only 
-binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause 
-binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause 
-boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6 
-bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6 
-bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6 
-bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6 
-bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6 
-c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause 
-c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause 
-ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC 
-ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC 
-ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC 
-ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC 
-ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC 
-certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC 
-colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause 
-compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause 
-conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause 
-conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause 
-cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause 
-fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause 
-fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause 
-frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only 
-frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only 
-frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only 
-frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only 
-frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only 
-gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause 
-gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause 
-gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause 
-gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause 
-gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause 
-gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause 
-idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause 
+binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only
+binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only
+binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only
+binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only
+binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause
+binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause
+boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6
+bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6
+bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6
+bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6
+bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6
+c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause
+c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause
+ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC
+ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC
+ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC
+ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC
+ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC
+certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC
+colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause
+compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause
+conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause
+conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause
+cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause
+fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause
+fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause
+frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only
+frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only
+frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only
+frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only
+frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only
+gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause
+gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause
+gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause
+gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause
+gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause
+gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause
+idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause
 kernel-headers_linux-64 2.6.32-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 kernel-headers_linux-aarch64 4.18.0-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later 
-keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later 
-ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only 
-ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only 
-libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause 
-libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause 
-libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause 
-libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause 
-libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause 
-libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl 
-libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl 
-libcurl 8.8.0-hca28451_1 (linux-64): curl 
-libcurl 8.8.0-hd5e4a3a_1 (win-64): curl 
-libcurl 8.8.0-hf9fcc65_1 (osx-64): curl 
-libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception 
-libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause 
-libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause 
-libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause 
-libev 4.33-hd590300_2 (linux-64): BSD-2-Clause 
-libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later 
-libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later 
-libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only 
-libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only 
-libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only 
-libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only 
-libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only 
-libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later 
-libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later 
-libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause 
-libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause 
-libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause 
-libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause 
-libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause 
-libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause 
-libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause 
-libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause 
-libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only 
-libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only 
-libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause 
-libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause 
-libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause 
-libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause 
-libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause 
-libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause 
-libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause 
-libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause 
-libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause 
-libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause 
-libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause 
-libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause 
-libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later 
-libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later 
-libzlib 1.3.1-h2466b09_1 (win-64): Zlib 
-libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-libzlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause 
-lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause 
-lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause 
-lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause 
-lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause 
-lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later 
-lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later 
-lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later 
-lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later 
-lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later 
+keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later
+keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later
+ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only
+ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only
+libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause
+libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause
+libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause
+libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause
+libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause
+libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl
+libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl
+libcurl 8.8.0-hca28451_1 (linux-64): curl
+libcurl 8.8.0-hd5e4a3a_1 (win-64): curl
+libcurl 8.8.0-hf9fcc65_1 (osx-64): curl
+libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception
+libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause
+libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause
+libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause
+libev 4.33-hd590300_2 (linux-64): BSD-2-Clause
+libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later
+libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later
+libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only
+libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only
+libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only
+libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only
+libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only
+libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later
+libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later
+libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause
+libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause
+libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause
+libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause
+libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause
+libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause
+libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause
+libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause
+libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only
+libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only
+libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause
+libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause
+libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause
+libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause
+libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause
+libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause
+libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause
+libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause
+libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause
+libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause
+libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause
+libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause
+libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later
+libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later
+libzlib 1.3.1-h2466b09_1 (win-64): Zlib
+libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+libzlib 1.3.1-h87427d6_1 (osx-64): Zlib
+libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause
+lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause
+lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause
+lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause
+lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause
+lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later
+lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later
+lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later
+lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later
+lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later
 m2w64-gcc-libgfortran 5.3.0-6 (win-64): GPL, LGPL, FDL, custom (Non-SPDX)
 m2w64-gcc-libs 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gcc-libs-core 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gmp 6.1.0-2 (win-64): LGPL3 (Non-SPDX)
 m2w64-libwinpthread-git 5.0.0.4634.697f757-2 (win-64): MIT, BSD (Non-SPDX)
-menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT 
-micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL 
-msys2-conda-epoch 20160418-1 (win-64): None (Non-SPDX)
-ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause 
-ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause 
-ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause 
-ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause 
-nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause 
-pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause 
-pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later 
-pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later 
-pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later 
-pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later 
-pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later 
-pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause 
-pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause 
-python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0 
-python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0 
-python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0 
-python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0 
-python 3.12.4-h889d299_0_cpython (win-64): Python-2.0 
-python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (win-64): BSD-3-Clause 
-readline 8.2-h8228510_1 (linux-64): GPL-3.0-only 
-readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only 
-readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only 
-readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only 
+menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT
+micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL
+msys2-conda-epoch 20160418-1 (win-64): no license
+ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause
+ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause
+ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause
+ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause
+nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause
+pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause
+pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later
+pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later
+pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later
+pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later
+pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later
+pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause
+pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause
+python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0
+python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0
+python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0
+python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0
+python 3.12.4-h889d299_0_cpython (win-64): Python-2.0
+python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause
+python_abi 3.12-4_cp312 (win-64): BSD-3-Clause
+readline 8.2-h8228510_1 (linux-64): GPL-3.0-only
+readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only
+readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only
+readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only
 sysroot_linux-64 2.12-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 sysroot_linux-aarch64 2.17-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-tk 8.6.13-h194ca79_0 (linux-aarch64): TCL 
-tk 8.6.13-h1abcd95_1 (osx-64): TCL 
-tk 8.6.13-h5083fa2_1 (osx-arm64): TCL 
-tk 8.6.13-h5226925_1 (win-64): TCL 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain 
-ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary 
-vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause 
-vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft 
-vc14_runtime 14.42.34438-hfd919c2_26 (win-64): LicenseRef-MicrosoftVisualCpp2015-2022Runtime 
-vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause 
-vs2015_runtime 14.42.34438-h7142326_26 (win-64): BSD-3-Clause 
+tk 8.6.13-h194ca79_0 (linux-aarch64): TCL
+tk 8.6.13-h1abcd95_1 (osx-64): TCL
+tk 8.6.13-h5083fa2_1 (osx-arm64): TCL
+tk 8.6.13-h5226925_1 (win-64): TCL
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain
+ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary
+vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause
+vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft
+vc14_runtime 14.42.34438-hfd919c2_26 (win-64): LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause
+vs2015_runtime 14.42.34438-h7142326_26 (win-64): BSD-3-Clause
 win_inet_pton 1.1.0-pyhd8ed1ab_6 (noarch): PUBLIC-DOMAIN (Non-SPDX)
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h57fd34a_0 (osx-arm64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h775f41a_0 (osx-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h8d14728_0 (win-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h9cdd2b7_0 (linux-aarch64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
-zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-zlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause 
-zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause 
-zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause 
-zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause 
-zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause 
-zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause 
-zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause 
-zstd 1.5.6-hb46c0d2_0 (osx-arm64): BSD-3-Clause 
+zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+zlib 1.3.1-h87427d6_1 (osx-64): Zlib
+zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause
+zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause
+zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause
+zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause
+zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause
+zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause
+zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause
+zstd 1.5.6-hb46c0d2_0 (osx-arm64): BSD-3-Clause
 
 ❌ Unsafe licenses found! ❌
 There were 168 safe licenses and 238 unsafe licenses.

--- a/tests/snapshots/integration_tests__check_test_default_use_case_pyproject.snap
+++ b/tests/snapshots/integration_tests__check_test_default_use_case_pyproject.snap
@@ -5,244 +5,244 @@ expression: stdout
 
 ❌ The following dependencies are unsafe:
 
-_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause 
-_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause 
+_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause
+_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause
 _sysroot_linux-aarch64_curr_repodata_hack 4-h57d6b7b_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only 
-binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only 
-binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only 
-binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only 
-binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause 
-binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause 
-boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6 
-bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6 
-bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6 
-bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6 
-bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6 
-c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause 
-c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause 
-ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC 
-ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC 
-ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC 
-ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC 
-ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC 
-certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC 
-colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause 
-compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause 
-conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause 
-conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause 
-cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause 
-fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause 
-fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause 
-frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only 
-frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only 
-frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only 
-frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only 
-frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only 
-gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause 
-gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause 
-gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause 
-gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause 
-gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause 
-gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause 
-idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause 
+binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only
+binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only
+binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only
+binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only
+binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause
+binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause
+boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6
+bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6
+bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6
+bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6
+bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6
+c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause
+c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause
+ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC
+ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC
+ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC
+ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC
+ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC
+certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC
+colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause
+compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause
+conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause
+conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause
+cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause
+fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause
+fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause
+frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only
+frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only
+frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only
+frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only
+frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only
+gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause
+gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause
+gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause
+gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause
+gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause
+gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause
+idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause
 kernel-headers_linux-64 2.6.32-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 kernel-headers_linux-aarch64 4.18.0-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later 
-keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later 
-ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only 
-ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only 
-libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause 
-libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause 
-libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause 
-libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause 
-libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause 
-libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl 
-libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl 
-libcurl 8.8.0-hca28451_1 (linux-64): curl 
-libcurl 8.8.0-hd5e4a3a_1 (win-64): curl 
-libcurl 8.8.0-hf9fcc65_1 (osx-64): curl 
-libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception 
-libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause 
-libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause 
-libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause 
-libev 4.33-hd590300_2 (linux-64): BSD-2-Clause 
-libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later 
-libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later 
-libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only 
-libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only 
-libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only 
-libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only 
-libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only 
-libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later 
-libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later 
-libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause 
-libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause 
-libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause 
-libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause 
-libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause 
-libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause 
-libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause 
-libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause 
-libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only 
-libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only 
-libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause 
-libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause 
-libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause 
-libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause 
-libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause 
-libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause 
-libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause 
-libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause 
-libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause 
-libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause 
-libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause 
-libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause 
-libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later 
-libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later 
-libzlib 1.3.1-h2466b09_1 (win-64): Zlib 
-libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-libzlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause 
-lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause 
-lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause 
-lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause 
-lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause 
-lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later 
-lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later 
-lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later 
-lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later 
-lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later 
+keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later
+keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later
+ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only
+ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only
+libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause
+libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause
+libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause
+libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause
+libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause
+libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl
+libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl
+libcurl 8.8.0-hca28451_1 (linux-64): curl
+libcurl 8.8.0-hd5e4a3a_1 (win-64): curl
+libcurl 8.8.0-hf9fcc65_1 (osx-64): curl
+libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception
+libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause
+libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause
+libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause
+libev 4.33-hd590300_2 (linux-64): BSD-2-Clause
+libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later
+libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later
+libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only
+libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only
+libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only
+libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only
+libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only
+libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later
+libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later
+libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause
+libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause
+libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause
+libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause
+libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause
+libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause
+libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause
+libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause
+libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only
+libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only
+libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause
+libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause
+libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause
+libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause
+libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause
+libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause
+libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause
+libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause
+libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause
+libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause
+libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause
+libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause
+libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later
+libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later
+libzlib 1.3.1-h2466b09_1 (win-64): Zlib
+libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+libzlib 1.3.1-h87427d6_1 (osx-64): Zlib
+libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause
+lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause
+lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause
+lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause
+lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause
+lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later
+lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later
+lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later
+lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later
+lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later
 m2w64-gcc-libgfortran 5.3.0-6 (win-64): GPL, LGPL, FDL, custom (Non-SPDX)
 m2w64-gcc-libs 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gcc-libs-core 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gmp 6.1.0-2 (win-64): LGPL3 (Non-SPDX)
 m2w64-libwinpthread-git 5.0.0.4634.697f757-2 (win-64): MIT, BSD (Non-SPDX)
-menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT 
-micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL 
-msys2-conda-epoch 20160418-1 (win-64): None (Non-SPDX)
-ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause 
-ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause 
-ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause 
-ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause 
-nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause 
-pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause 
-pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later 
-pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later 
-pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later 
-pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later 
-pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later 
-pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause 
-pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause 
-python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0 
-python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0 
-python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0 
-python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0 
-python 3.12.4-h889d299_0_cpython (win-64): Python-2.0 
-python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (win-64): BSD-3-Clause 
-readline 8.2-h8228510_1 (linux-64): GPL-3.0-only 
-readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only 
-readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only 
-readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only 
+menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT
+micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL
+msys2-conda-epoch 20160418-1 (win-64): no license
+ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause
+ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause
+ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause
+ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause
+nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause
+pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause
+pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later
+pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later
+pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later
+pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later
+pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later
+pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause
+pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause
+python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0
+python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0
+python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0
+python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0
+python 3.12.4-h889d299_0_cpython (win-64): Python-2.0
+python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause
+python_abi 3.12-4_cp312 (win-64): BSD-3-Clause
+readline 8.2-h8228510_1 (linux-64): GPL-3.0-only
+readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only
+readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only
+readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only
 sysroot_linux-64 2.12-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 sysroot_linux-aarch64 2.17-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-tk 8.6.13-h194ca79_0 (linux-aarch64): TCL 
-tk 8.6.13-h1abcd95_1 (osx-64): TCL 
-tk 8.6.13-h5083fa2_1 (osx-arm64): TCL 
-tk 8.6.13-h5226925_1 (win-64): TCL 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain 
-ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary 
-vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause 
-vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft 
-vc14_runtime 14.42.34438-hfd919c2_26 (win-64): LicenseRef-MicrosoftVisualCpp2015-2022Runtime 
-vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause 
-vs2015_runtime 14.42.34438-h7142326_26 (win-64): BSD-3-Clause 
+tk 8.6.13-h194ca79_0 (linux-aarch64): TCL
+tk 8.6.13-h1abcd95_1 (osx-64): TCL
+tk 8.6.13-h5083fa2_1 (osx-arm64): TCL
+tk 8.6.13-h5226925_1 (win-64): TCL
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain
+ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary
+vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause
+vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft
+vc14_runtime 14.42.34438-hfd919c2_26 (win-64): LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause
+vs2015_runtime 14.42.34438-h7142326_26 (win-64): BSD-3-Clause
 win_inet_pton 1.1.0-pyhd8ed1ab_6 (noarch): PUBLIC-DOMAIN (Non-SPDX)
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h57fd34a_0 (osx-arm64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h775f41a_0 (osx-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h8d14728_0 (win-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h9cdd2b7_0 (linux-aarch64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
-zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-zlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause 
-zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause 
-zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause 
-zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause 
-zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause 
-zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause 
-zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause 
-zstd 1.5.6-hb46c0d2_0 (osx-arm64): BSD-3-Clause 
+zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+zlib 1.3.1-h87427d6_1 (osx-64): Zlib
+zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause
+zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause
+zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause
+zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause
+zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause
+zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause
+zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause
+zstd 1.5.6-hb46c0d2_0 (osx-arm64): BSD-3-Clause
 
 ❌ Unsafe licenses found! ❌
 There were 168 safe licenses and 238 unsafe licenses.

--- a/tests/snapshots/integration_tests__exception_check.snap
+++ b/tests/snapshots/integration_tests__exception_check.snap
@@ -5,15 +5,15 @@ expression: output
 
 ❌ The following dependencies are unsafe:
 
-distlib 0.3.8-pyhd8ed1ab_0 (noarch): Apache-2.0 
-distro 1.9.0-pyhd8ed1ab_0 (noarch): Apache-2.0 
-openssl 3.3.1-h2466b09_1 (win-64): Apache-2.0 
-openssl 3.3.1-h4ab18f5_1 (linux-64): Apache-2.0 
-openssl 3.3.1-h68df207_1 (linux-aarch64): Apache-2.0 
-openssl 3.3.1-h87427d6_1 (osx-64): Apache-2.0 
-openssl 3.3.1-hfb2fe0b_1 (osx-arm64): Apache-2.0 
-packaging 24.1-pyhd8ed1ab_0 (noarch): Apache-2.0 
-requests 2.32.3-pyhd8ed1ab_0 (noarch): Apache-2.0 
+distlib 0.3.8-pyhd8ed1ab_0 (noarch): Apache-2.0
+distro 1.9.0-pyhd8ed1ab_0 (noarch): Apache-2.0
+openssl 3.3.1-h2466b09_1 (win-64): Apache-2.0
+openssl 3.3.1-h4ab18f5_1 (linux-64): Apache-2.0
+openssl 3.3.1-h68df207_1 (linux-aarch64): Apache-2.0
+openssl 3.3.1-h87427d6_1 (osx-64): Apache-2.0
+openssl 3.3.1-hfb2fe0b_1 (osx-arm64): Apache-2.0
+packaging 24.1-pyhd8ed1ab_0 (noarch): Apache-2.0
+requests 2.32.3-pyhd8ed1ab_0 (noarch): Apache-2.0
 
 ❌ Unsafe licenses found! ❌
 There were 373 safe licenses and 9 unsafe licenses.

--- a/tests/snapshots/integration_tests__list.snap
+++ b/tests/snapshots/integration_tests__list.snap
@@ -2,24 +2,24 @@
 source: tests/integration_tests.rs
 expression: output
 ---
-_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause 
-binutils_impl_linux-64 2.43-h4bf12b8_4 (linux-64): GPL-3.0-only 
-ca-certificates 2025.4.26-hbd8a1cb_0 (noarch): ISC 
-gcc_impl_linux-64 13.3.0-h1e990d8_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-k9s 0.50.4-h643be8f_0 (linux-64): Apache-2.0 
+_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause
+binutils_impl_linux-64 2.43-h4bf12b8_4 (linux-64): GPL-3.0-only
+ca-certificates 2025.4.26-hbd8a1cb_0 (noarch): ISC
+gcc_impl_linux-64 13.3.0-h1e990d8_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+k9s 0.50.4-h643be8f_0 (linux-64): Apache-2.0
 kernel-headers_linux-64 3.10.0-he073ed8_18 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-ld_impl_linux-64 2.43-h712a8e2_4 (linux-64): GPL-3.0-only 
-libgcc 15.1.0-h767d61c_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-64 13.3.0-hc03c837_102 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 15.1.0-h69a702a_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 15.1.0-h767d61c_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 13.3.0-he8ea267_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx 15.1.0-h8f9b012_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libzlib 1.3.1-hb9d3cd8_2 (linux-64): Zlib 
-openssl 3.5.0-h7b32b05_1 (linux-64): Apache-2.0 
-pkg-config 0.29.2-h4bc722e_1009 (linux-64): GPL-2.0-or-later 
-rust 1.77.2-h70c747d_1 (linux-64): MIT 
-rust-std-x86_64-unknown-linux-gnu 1.77.2-h2c6d0dc_1 (noarch): MIT 
+ld_impl_linux-64 2.43-h712a8e2_4 (linux-64): GPL-3.0-only
+libgcc 15.1.0-h767d61c_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-64 13.3.0-hc03c837_102 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 15.1.0-h69a702a_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 15.1.0-h767d61c_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 13.3.0-he8ea267_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx 15.1.0-h8f9b012_2 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libzlib 1.3.1-hb9d3cd8_2 (linux-64): Zlib
+openssl 3.5.0-h7b32b05_1 (linux-64): Apache-2.0
+pkg-config 0.29.2-h4bc722e_1009 (linux-64): GPL-2.0-or-later
+rust 1.77.2-h70c747d_1 (linux-64): MIT
+rust-std-x86_64-unknown-linux-gnu 1.77.2-h2c6d0dc_1 (noarch): MIT
 sysroot_linux-64 2.17-h0157908_18 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-tzdata 2025b-h78e105d_0 (noarch): LicenseRef-Public-Domain 
+tzdata 2025b-h78e105d_0 (noarch): LicenseRef-Public-Domain
 vhs 0.7.2-ha770c72_0 (linux-64): MIT

--- a/tests/snapshots/integration_tests__list_test_default_use_case.snap
+++ b/tests/snapshots/integration_tests__list_test_default_use_case.snap
@@ -2,409 +2,409 @@
 source: tests/integration_tests.rs
 expression: stdout
 ---
-_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause 
-_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause 
+_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause
+_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause
 _sysroot_linux-aarch64_curr_repodata_hack 4-h57d6b7b_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-archspec 0.2.3-pyhd8ed1ab_0 (noarch): MIT OR Apache-2.0 
-binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only 
-binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only 
-binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only 
-binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only 
-binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause 
-binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause 
-boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-brotli-python 1.1.0-py312h2aa54b4_1 (linux-aarch64): MIT 
-brotli-python 1.1.0-py312h30efb56_1 (linux-64): MIT 
-brotli-python 1.1.0-py312h53d5487_1 (win-64): MIT 
-brotli-python 1.1.0-py312h9f69965_1 (osx-arm64): MIT 
-brotli-python 1.1.0-py312heafc425_1 (osx-64): MIT 
-bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6 
-bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6 
-bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6 
-bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6 
-bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6 
-c-ares 1.28.1-h10d778d_0 (osx-64): MIT 
-c-ares 1.28.1-h31becfc_0 (linux-aarch64): MIT 
-c-ares 1.28.1-h93a5062_0 (osx-arm64): MIT 
-c-ares 1.28.1-hd590300_0 (linux-64): MIT 
-c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause 
-c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause 
-ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC 
-ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC 
-ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC 
-ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC 
-ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC 
-certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC 
-cffi 1.16.0-py312h38bf5a0_0 (osx-64): MIT 
-cffi 1.16.0-py312h8e38eb3_0 (osx-arm64): MIT 
-cffi 1.16.0-py312he70551f_0 (win-64): MIT 
-cffi 1.16.0-py312hf06ca03_0 (linux-64): MIT 
-cffi 1.16.0-py312hf3c74c0_0 (linux-aarch64): MIT 
-cfgv 3.3.1-pyhd8ed1ab_0 (noarch): MIT 
-charset-normalizer 3.3.2-pyhd8ed1ab_0 (noarch): MIT 
-colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause 
-compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause 
-conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause 
-conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause 
-cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause 
-distlib 0.3.8-pyhd8ed1ab_0 (noarch): Apache-2.0 
-distro 1.9.0-pyhd8ed1ab_0 (noarch): Apache-2.0 
-filelock 3.15.4-pyhd8ed1ab_0 (noarch): Unlicense 
-fmt 10.2.1-h00ab1b0_0 (linux-64): MIT 
-fmt 10.2.1-h181d51b_0 (win-64): MIT 
-fmt 10.2.1-h2a328a1_0 (linux-aarch64): MIT 
-fmt 10.2.1-h2ffa867_0 (osx-arm64): MIT 
-fmt 10.2.1-h7728843_0 (osx-64): MIT 
-fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause 
-fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause 
-frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only 
-frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only 
-frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only 
-frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only 
-frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only 
-gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause 
-gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause 
-gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause 
-gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause 
-gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause 
-gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause 
-h2 4.1.0-pyhd8ed1ab_0 (noarch): MIT 
-hpack 4.0.0-pyh9f0ad1d_0 (noarch): MIT 
-hyperframe 6.0.1-pyhd8ed1ab_0 (noarch): MIT 
-icu 73.2-h59595ed_0 (linux-64): MIT 
-icu 73.2-h787c7f5_0 (linux-aarch64): MIT 
-icu 73.2-hc8870d7_0 (osx-arm64): MIT 
-icu 73.2-hf5e326d_0 (osx-64): MIT 
-identify 2.5.36-pyhd8ed1ab_0 (noarch): MIT 
-idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause 
-k9s 0.40.5-h36c15f3_1 (win-64): Apache-2.0 
-k9s 0.40.5-h87715bd_1 (osx-arm64): Apache-2.0 
-k9s 0.40.5-hc7f0b10_1 (osx-64): Apache-2.0 
-k9s 0.40.5-hd24410f_1 (linux-aarch64): Apache-2.0 
-k9s 0.40.5-he91c749_1 (linux-64): Apache-2.0 
+archspec 0.2.3-pyhd8ed1ab_0 (noarch): MIT OR Apache-2.0
+binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only
+binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only
+binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only
+binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only
+binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause
+binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause
+boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+brotli-python 1.1.0-py312h2aa54b4_1 (linux-aarch64): MIT
+brotli-python 1.1.0-py312h30efb56_1 (linux-64): MIT
+brotli-python 1.1.0-py312h53d5487_1 (win-64): MIT
+brotli-python 1.1.0-py312h9f69965_1 (osx-arm64): MIT
+brotli-python 1.1.0-py312heafc425_1 (osx-64): MIT
+bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6
+bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6
+bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6
+bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6
+bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6
+c-ares 1.28.1-h10d778d_0 (osx-64): MIT
+c-ares 1.28.1-h31becfc_0 (linux-aarch64): MIT
+c-ares 1.28.1-h93a5062_0 (osx-arm64): MIT
+c-ares 1.28.1-hd590300_0 (linux-64): MIT
+c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause
+c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause
+ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC
+ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC
+ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC
+ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC
+ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC
+certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC
+cffi 1.16.0-py312h38bf5a0_0 (osx-64): MIT
+cffi 1.16.0-py312h8e38eb3_0 (osx-arm64): MIT
+cffi 1.16.0-py312he70551f_0 (win-64): MIT
+cffi 1.16.0-py312hf06ca03_0 (linux-64): MIT
+cffi 1.16.0-py312hf3c74c0_0 (linux-aarch64): MIT
+cfgv 3.3.1-pyhd8ed1ab_0 (noarch): MIT
+charset-normalizer 3.3.2-pyhd8ed1ab_0 (noarch): MIT
+colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause
+compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause
+conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause
+conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause
+cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause
+distlib 0.3.8-pyhd8ed1ab_0 (noarch): Apache-2.0
+distro 1.9.0-pyhd8ed1ab_0 (noarch): Apache-2.0
+filelock 3.15.4-pyhd8ed1ab_0 (noarch): Unlicense
+fmt 10.2.1-h00ab1b0_0 (linux-64): MIT
+fmt 10.2.1-h181d51b_0 (win-64): MIT
+fmt 10.2.1-h2a328a1_0 (linux-aarch64): MIT
+fmt 10.2.1-h2ffa867_0 (osx-arm64): MIT
+fmt 10.2.1-h7728843_0 (osx-64): MIT
+fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause
+fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause
+frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only
+frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only
+frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only
+frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only
+frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only
+gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause
+gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause
+gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause
+gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause
+gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause
+gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause
+h2 4.1.0-pyhd8ed1ab_0 (noarch): MIT
+hpack 4.0.0-pyh9f0ad1d_0 (noarch): MIT
+hyperframe 6.0.1-pyhd8ed1ab_0 (noarch): MIT
+icu 73.2-h59595ed_0 (linux-64): MIT
+icu 73.2-h787c7f5_0 (linux-aarch64): MIT
+icu 73.2-hc8870d7_0 (osx-arm64): MIT
+icu 73.2-hf5e326d_0 (osx-64): MIT
+identify 2.5.36-pyhd8ed1ab_0 (noarch): MIT
+idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause
+k9s 0.40.5-h36c15f3_1 (win-64): Apache-2.0
+k9s 0.40.5-h87715bd_1 (osx-arm64): Apache-2.0
+k9s 0.40.5-hc7f0b10_1 (osx-64): Apache-2.0
+k9s 0.40.5-hd24410f_1 (linux-aarch64): Apache-2.0
+k9s 0.40.5-he91c749_1 (linux-64): Apache-2.0
 kernel-headers_linux-64 2.6.32-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 kernel-headers_linux-aarch64 4.18.0-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later 
-keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later 
-krb5 1.21.3-h237132a_0 (osx-arm64): MIT 
-krb5 1.21.3-h37d8d59_0 (osx-64): MIT 
-krb5 1.21.3-h50a48e9_0 (linux-aarch64): MIT 
-krb5 1.21.3-h659f571_0 (linux-64): MIT 
-krb5 1.21.3-hdf4eb48_0 (win-64): MIT 
-ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only 
-ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only 
-libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause 
-libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause 
-libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause 
-libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause 
-libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause 
-libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl 
-libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl 
-libcurl 8.8.0-hca28451_1 (linux-64): curl 
-libcurl 8.8.0-hd5e4a3a_1 (win-64): curl 
-libcurl 8.8.0-hf9fcc65_1 (osx-64): curl 
-libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception 
-libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause 
-libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause 
-libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause 
-libev 4.33-hd590300_2 (linux-64): BSD-2-Clause 
-libexpat 2.6.2-h2f0025b_0 (linux-aarch64): MIT 
-libexpat 2.6.2-h59595ed_0 (linux-64): MIT 
-libexpat 2.6.2-h63175ca_0 (win-64): MIT 
-libexpat 2.6.2-h73e2aa4_0 (osx-64): MIT 
-libexpat 2.6.2-hebf3989_0 (osx-arm64): MIT 
-libffi 3.4.2-h0d85af4_5 (osx-64): MIT 
-libffi 3.4.2-h3422bc3_5 (osx-arm64): MIT 
-libffi 3.4.2-h3557bc0_5 (linux-aarch64): MIT 
-libffi 3.4.2-h7f98852_5 (linux-64): MIT 
-libffi 3.4.2-h8ffe710_5 (win-64): MIT 
-libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later 
-libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later 
-libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only 
-libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only 
-libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only 
-libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only 
-libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only 
-libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later 
-libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later 
-libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause 
-libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause 
-libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause 
-libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause 
-libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause 
-libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause 
-libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause 
-libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause 
-libnghttp2 1.58.0-h47da74e_1 (linux-64): MIT 
-libnghttp2 1.58.0-h64cf6d3_1 (osx-64): MIT 
-libnghttp2 1.58.0-ha4dd798_1 (osx-arm64): MIT 
-libnghttp2 1.58.0-hb0e430d_1 (linux-aarch64): MIT 
-libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only 
-libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only 
-libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause 
-libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause 
-libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause 
-libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause 
-libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause 
-libsqlite 3.46.0-h1b8f9f3_0 (osx-64): Unlicense 
-libsqlite 3.46.0-h2466b09_0 (win-64): Unlicense 
-libsqlite 3.46.0-hde9e2c9_0 (linux-64): Unlicense 
-libsqlite 3.46.0-hf51ef55_0 (linux-aarch64): Unlicense 
-libsqlite 3.46.0-hfb93653_0 (osx-arm64): Unlicense 
-libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause 
-libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause 
-libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause 
-libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause 
-libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause 
-libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause 
-libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause 
-libuv 1.48.0-h31becfc_0 (linux-aarch64): MIT 
-libuv 1.48.0-h67532ce_0 (osx-64): MIT 
-libuv 1.48.0-h93a5062_0 (osx-arm64): MIT 
-libuv 1.48.0-hd590300_0 (linux-64): MIT 
-libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later 
-libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later 
-libxml2 2.12.7-h283a6d9_1 (win-64): MIT 
-libxml2 2.12.7-h3e169fe_1 (osx-64): MIT 
-libxml2 2.12.7-h49dc7a2_1 (linux-aarch64): MIT 
-libxml2 2.12.7-ha661575_1 (osx-arm64): MIT 
-libxml2 2.12.7-hc051c1a_1 (linux-64): MIT 
-libzlib 1.3.1-h2466b09_1 (win-64): Zlib 
-libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-libzlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause 
-lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause 
-lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause 
-lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause 
-lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause 
-lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later 
-lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later 
-lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later 
-lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later 
-lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later 
+keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later
+keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later
+krb5 1.21.3-h237132a_0 (osx-arm64): MIT
+krb5 1.21.3-h37d8d59_0 (osx-64): MIT
+krb5 1.21.3-h50a48e9_0 (linux-aarch64): MIT
+krb5 1.21.3-h659f571_0 (linux-64): MIT
+krb5 1.21.3-hdf4eb48_0 (win-64): MIT
+ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only
+ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only
+libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause
+libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause
+libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause
+libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause
+libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause
+libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl
+libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl
+libcurl 8.8.0-hca28451_1 (linux-64): curl
+libcurl 8.8.0-hd5e4a3a_1 (win-64): curl
+libcurl 8.8.0-hf9fcc65_1 (osx-64): curl
+libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception
+libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause
+libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause
+libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause
+libev 4.33-hd590300_2 (linux-64): BSD-2-Clause
+libexpat 2.6.2-h2f0025b_0 (linux-aarch64): MIT
+libexpat 2.6.2-h59595ed_0 (linux-64): MIT
+libexpat 2.6.2-h63175ca_0 (win-64): MIT
+libexpat 2.6.2-h73e2aa4_0 (osx-64): MIT
+libexpat 2.6.2-hebf3989_0 (osx-arm64): MIT
+libffi 3.4.2-h0d85af4_5 (osx-64): MIT
+libffi 3.4.2-h3422bc3_5 (osx-arm64): MIT
+libffi 3.4.2-h3557bc0_5 (linux-aarch64): MIT
+libffi 3.4.2-h7f98852_5 (linux-64): MIT
+libffi 3.4.2-h8ffe710_5 (win-64): MIT
+libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later
+libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later
+libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only
+libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only
+libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only
+libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only
+libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only
+libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later
+libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later
+libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause
+libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause
+libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause
+libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause
+libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause
+libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause
+libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause
+libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause
+libnghttp2 1.58.0-h47da74e_1 (linux-64): MIT
+libnghttp2 1.58.0-h64cf6d3_1 (osx-64): MIT
+libnghttp2 1.58.0-ha4dd798_1 (osx-arm64): MIT
+libnghttp2 1.58.0-hb0e430d_1 (linux-aarch64): MIT
+libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only
+libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only
+libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause
+libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause
+libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause
+libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause
+libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause
+libsqlite 3.46.0-h1b8f9f3_0 (osx-64): Unlicense
+libsqlite 3.46.0-h2466b09_0 (win-64): Unlicense
+libsqlite 3.46.0-hde9e2c9_0 (linux-64): Unlicense
+libsqlite 3.46.0-hf51ef55_0 (linux-aarch64): Unlicense
+libsqlite 3.46.0-hfb93653_0 (osx-arm64): Unlicense
+libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause
+libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause
+libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause
+libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause
+libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause
+libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause
+libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause
+libuv 1.48.0-h31becfc_0 (linux-aarch64): MIT
+libuv 1.48.0-h67532ce_0 (osx-64): MIT
+libuv 1.48.0-h93a5062_0 (osx-arm64): MIT
+libuv 1.48.0-hd590300_0 (linux-64): MIT
+libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later
+libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later
+libxml2 2.12.7-h283a6d9_1 (win-64): MIT
+libxml2 2.12.7-h3e169fe_1 (osx-64): MIT
+libxml2 2.12.7-h49dc7a2_1 (linux-aarch64): MIT
+libxml2 2.12.7-ha661575_1 (osx-arm64): MIT
+libxml2 2.12.7-hc051c1a_1 (linux-64): MIT
+libzlib 1.3.1-h2466b09_1 (win-64): Zlib
+libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+libzlib 1.3.1-h87427d6_1 (osx-64): Zlib
+libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause
+lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause
+lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause
+lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause
+lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause
+lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later
+lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later
+lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later
+lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later
+lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later
 m2w64-gcc-libgfortran 5.3.0-6 (win-64): GPL, LGPL, FDL, custom (Non-SPDX)
 m2w64-gcc-libs 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gcc-libs-core 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gmp 6.1.0-2 (win-64): LGPL3 (Non-SPDX)
 m2w64-libwinpthread-git 5.0.0.4634.697f757-2 (win-64): MIT, BSD (Non-SPDX)
-menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT 
-micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL 
-msys2-conda-epoch 20160418-1 (win-64): None (Non-SPDX)
-ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause 
-ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause 
-ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause 
-ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause 
-nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-nodejs 20.12.2-h3b52c9b_0 (osx-arm64): MIT 
-nodejs 20.12.2-h57928b3_0 (win-64): MIT 
-nodejs 20.12.2-hb753e55_0 (linux-64): MIT 
-nodejs 20.12.2-hc1f8a26_0 (linux-aarch64): MIT 
-nodejs 20.12.2-hfc0f20e_0 (osx-64): MIT 
-openssl 3.3.1-h2466b09_1 (win-64): Apache-2.0 
-openssl 3.3.1-h4ab18f5_1 (linux-64): Apache-2.0 
-openssl 3.3.1-h68df207_1 (linux-aarch64): Apache-2.0 
-openssl 3.3.1-h87427d6_1 (osx-64): Apache-2.0 
-openssl 3.3.1-hfb2fe0b_1 (osx-arm64): Apache-2.0 
-packaging 24.1-pyhd8ed1ab_0 (noarch): Apache-2.0 
-pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause 
-pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause 
-pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later 
-pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later 
-pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later 
-pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later 
-pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later 
-platformdirs 4.2.2-pyhd8ed1ab_0 (noarch): MIT 
-pluggy 1.5.0-pyhd8ed1ab_0 (noarch): MIT 
-pre-commit 3.7.1-pyha770c72_0 (noarch): MIT 
-pre-commit-hooks 4.6.0-pyhd8ed1ab_0 (noarch): MIT 
-prettier 3.3.2-h91d9761_0 (linux-64): MIT 
-prettier 3.3.2-hb408824_0 (osx-64): MIT 
-prettier 3.3.2-hb4d2b26_0 (win-64): MIT 
-prettier 3.3.2-hdbbef84_0 (linux-aarch64): MIT 
-prettier 3.3.2-he434342_0 (osx-arm64): MIT 
-pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause 
-pycosat 0.6.6-py312h02f2b3b_0 (osx-arm64): MIT 
-pycosat 0.6.6-py312h104f124_0 (osx-64): MIT 
-pycosat 0.6.6-py312h98912ed_0 (linux-64): MIT 
-pycosat 0.6.6-py312hdd3e373_0 (linux-aarch64): MIT 
-pycosat 0.6.6-py312he70551f_0 (win-64): MIT 
-pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause 
-python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0 
-python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0 
-python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0 
-python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0 
-python 3.12.4-h889d299_0_cpython (win-64): Python-2.0 
-python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (win-64): BSD-3-Clause 
-pyyaml 6.0.1-py312h02f2b3b_1 (osx-arm64): MIT 
-pyyaml 6.0.1-py312h104f124_1 (osx-64): MIT 
-pyyaml 6.0.1-py312h98912ed_1 (linux-64): MIT 
-pyyaml 6.0.1-py312hdd3e373_1 (linux-aarch64): MIT 
-pyyaml 6.0.1-py312he70551f_1 (win-64): MIT 
-readline 8.2-h8228510_1 (linux-64): GPL-3.0-only 
-readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only 
-readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only 
-readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only 
-reproc 14.2.4.post0-h10d778d_1 (osx-64): MIT 
-reproc 14.2.4.post0-h31becfc_1 (linux-aarch64): MIT 
-reproc 14.2.4.post0-h93a5062_1 (osx-arm64): MIT 
-reproc 14.2.4.post0-hcfcfb64_1 (win-64): MIT 
-reproc 14.2.4.post0-hd590300_1 (linux-64): MIT 
-reproc-cpp 14.2.4.post0-h2f0025b_1 (linux-aarch64): MIT 
-reproc-cpp 14.2.4.post0-h59595ed_1 (linux-64): MIT 
-reproc-cpp 14.2.4.post0-h63175ca_1 (win-64): MIT 
-reproc-cpp 14.2.4.post0-h93d8f39_1 (osx-64): MIT 
-reproc-cpp 14.2.4.post0-h965bd2d_1 (osx-arm64): MIT 
-requests 2.32.3-pyhd8ed1ab_0 (noarch): Apache-2.0 
-ruamel.yaml 0.18.6-py312h41838bb_0 (osx-64): MIT 
-ruamel.yaml 0.18.6-py312h98912ed_0 (linux-64): MIT 
-ruamel.yaml 0.18.6-py312hdd3e373_0 (linux-aarch64): MIT 
-ruamel.yaml 0.18.6-py312he37b823_0 (osx-arm64): MIT 
-ruamel.yaml 0.18.6-py312he70551f_0 (win-64): MIT 
-ruamel.yaml.clib 0.2.8-py312h41838bb_0 (osx-64): MIT 
-ruamel.yaml.clib 0.2.8-py312h98912ed_0 (linux-64): MIT 
-ruamel.yaml.clib 0.2.8-py312hdd3e373_0 (linux-aarch64): MIT 
-ruamel.yaml.clib 0.2.8-py312he37b823_0 (osx-arm64): MIT 
-ruamel.yaml.clib 0.2.8-py312he70551f_0 (win-64): MIT 
-rust 1.77.2-h4ff7c5d_1 (osx-arm64): MIT 
-rust 1.77.2-h70c747d_1 (linux-64): MIT 
-rust 1.77.2-h7e1429e_1 (osx-64): MIT 
-rust 1.77.2-h9d3d833_1 (linux-aarch64): MIT 
-rust 1.77.2-hf8d6059_1 (win-64): MIT 
-rust-std-aarch64-apple-darwin 1.77.2-hf6ec828_1 (noarch): MIT 
-rust-std-aarch64-unknown-linux-gnu 1.77.2-hbe8e118_1 (noarch): MIT 
-rust-std-x86_64-apple-darwin 1.77.2-h38e4360_1 (noarch): MIT 
-rust-std-x86_64-pc-windows-msvc 1.77.2-h17fc481_1 (noarch): MIT 
-rust-std-x86_64-unknown-linux-gnu 1.77.2-h2c6d0dc_1 (noarch): MIT 
-setuptools 70.1.1-pyhd8ed1ab_0 (noarch): MIT 
+menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT
+micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL
+msys2-conda-epoch 20160418-1 (win-64): no license
+ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause
+ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause
+ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause
+ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause
+nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+nodejs 20.12.2-h3b52c9b_0 (osx-arm64): MIT
+nodejs 20.12.2-h57928b3_0 (win-64): MIT
+nodejs 20.12.2-hb753e55_0 (linux-64): MIT
+nodejs 20.12.2-hc1f8a26_0 (linux-aarch64): MIT
+nodejs 20.12.2-hfc0f20e_0 (osx-64): MIT
+openssl 3.3.1-h2466b09_1 (win-64): Apache-2.0
+openssl 3.3.1-h4ab18f5_1 (linux-64): Apache-2.0
+openssl 3.3.1-h68df207_1 (linux-aarch64): Apache-2.0
+openssl 3.3.1-h87427d6_1 (osx-64): Apache-2.0
+openssl 3.3.1-hfb2fe0b_1 (osx-arm64): Apache-2.0
+packaging 24.1-pyhd8ed1ab_0 (noarch): Apache-2.0
+pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause
+pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause
+pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later
+pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later
+pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later
+pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later
+pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later
+platformdirs 4.2.2-pyhd8ed1ab_0 (noarch): MIT
+pluggy 1.5.0-pyhd8ed1ab_0 (noarch): MIT
+pre-commit 3.7.1-pyha770c72_0 (noarch): MIT
+pre-commit-hooks 4.6.0-pyhd8ed1ab_0 (noarch): MIT
+prettier 3.3.2-h91d9761_0 (linux-64): MIT
+prettier 3.3.2-hb408824_0 (osx-64): MIT
+prettier 3.3.2-hb4d2b26_0 (win-64): MIT
+prettier 3.3.2-hdbbef84_0 (linux-aarch64): MIT
+prettier 3.3.2-he434342_0 (osx-arm64): MIT
+pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause
+pycosat 0.6.6-py312h02f2b3b_0 (osx-arm64): MIT
+pycosat 0.6.6-py312h104f124_0 (osx-64): MIT
+pycosat 0.6.6-py312h98912ed_0 (linux-64): MIT
+pycosat 0.6.6-py312hdd3e373_0 (linux-aarch64): MIT
+pycosat 0.6.6-py312he70551f_0 (win-64): MIT
+pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause
+python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0
+python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0
+python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0
+python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0
+python 3.12.4-h889d299_0_cpython (win-64): Python-2.0
+python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause
+python_abi 3.12-4_cp312 (win-64): BSD-3-Clause
+pyyaml 6.0.1-py312h02f2b3b_1 (osx-arm64): MIT
+pyyaml 6.0.1-py312h104f124_1 (osx-64): MIT
+pyyaml 6.0.1-py312h98912ed_1 (linux-64): MIT
+pyyaml 6.0.1-py312hdd3e373_1 (linux-aarch64): MIT
+pyyaml 6.0.1-py312he70551f_1 (win-64): MIT
+readline 8.2-h8228510_1 (linux-64): GPL-3.0-only
+readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only
+readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only
+readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only
+reproc 14.2.4.post0-h10d778d_1 (osx-64): MIT
+reproc 14.2.4.post0-h31becfc_1 (linux-aarch64): MIT
+reproc 14.2.4.post0-h93a5062_1 (osx-arm64): MIT
+reproc 14.2.4.post0-hcfcfb64_1 (win-64): MIT
+reproc 14.2.4.post0-hd590300_1 (linux-64): MIT
+reproc-cpp 14.2.4.post0-h2f0025b_1 (linux-aarch64): MIT
+reproc-cpp 14.2.4.post0-h59595ed_1 (linux-64): MIT
+reproc-cpp 14.2.4.post0-h63175ca_1 (win-64): MIT
+reproc-cpp 14.2.4.post0-h93d8f39_1 (osx-64): MIT
+reproc-cpp 14.2.4.post0-h965bd2d_1 (osx-arm64): MIT
+requests 2.32.3-pyhd8ed1ab_0 (noarch): Apache-2.0
+ruamel.yaml 0.18.6-py312h41838bb_0 (osx-64): MIT
+ruamel.yaml 0.18.6-py312h98912ed_0 (linux-64): MIT
+ruamel.yaml 0.18.6-py312hdd3e373_0 (linux-aarch64): MIT
+ruamel.yaml 0.18.6-py312he37b823_0 (osx-arm64): MIT
+ruamel.yaml 0.18.6-py312he70551f_0 (win-64): MIT
+ruamel.yaml.clib 0.2.8-py312h41838bb_0 (osx-64): MIT
+ruamel.yaml.clib 0.2.8-py312h98912ed_0 (linux-64): MIT
+ruamel.yaml.clib 0.2.8-py312hdd3e373_0 (linux-aarch64): MIT
+ruamel.yaml.clib 0.2.8-py312he37b823_0 (osx-arm64): MIT
+ruamel.yaml.clib 0.2.8-py312he70551f_0 (win-64): MIT
+rust 1.77.2-h4ff7c5d_1 (osx-arm64): MIT
+rust 1.77.2-h70c747d_1 (linux-64): MIT
+rust 1.77.2-h7e1429e_1 (osx-64): MIT
+rust 1.77.2-h9d3d833_1 (linux-aarch64): MIT
+rust 1.77.2-hf8d6059_1 (win-64): MIT
+rust-std-aarch64-apple-darwin 1.77.2-hf6ec828_1 (noarch): MIT
+rust-std-aarch64-unknown-linux-gnu 1.77.2-hbe8e118_1 (noarch): MIT
+rust-std-x86_64-apple-darwin 1.77.2-h38e4360_1 (noarch): MIT
+rust-std-x86_64-pc-windows-msvc 1.77.2-h17fc481_1 (noarch): MIT
+rust-std-x86_64-unknown-linux-gnu 1.77.2-h2c6d0dc_1 (noarch): MIT
+setuptools 70.1.1-pyhd8ed1ab_0 (noarch): MIT
 sysroot_linux-64 2.12-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 sysroot_linux-aarch64 2.17-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-taplo 0.9.1-h16c8c8b_0 (osx-arm64): MIT 
-taplo 0.9.1-h1ff36dd_0 (linux-64): MIT 
-taplo 0.9.1-h236d3af_0 (osx-64): MIT 
-taplo 0.9.1-h7f3b576_0 (win-64): MIT 
-taplo 0.9.1-hb8f9562_0 (linux-aarch64): MIT 
-tk 8.6.13-h194ca79_0 (linux-aarch64): TCL 
-tk 8.6.13-h1abcd95_1 (osx-64): TCL 
-tk 8.6.13-h5083fa2_1 (osx-arm64): TCL 
-tk 8.6.13-h5226925_1 (win-64): TCL 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tomli 2.0.1-pyhd8ed1ab_0 (noarch): MIT 
-tqdm 4.66.4-pyhd8ed1ab_0 (noarch): MPL-2.0 or MIT 
-truststore 0.8.0-pyhd8ed1ab_0 (noarch): MIT 
-typos 1.22.7-h09b8157_0 (linux-aarch64): MIT 
-typos 1.22.7-h686f776_0 (osx-64): MIT 
-typos 1.22.7-h6e96688_0 (osx-arm64): MIT 
-typos 1.22.7-h813c833_0 (win-64): MIT 
-typos 1.22.7-he9194b0_0 (linux-64): MIT 
-tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain 
-ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary 
-ukkonen 1.0.1-py312h0d7def4_4 (win-64): MIT 
-ukkonen 1.0.1-py312h389731b_4 (osx-arm64): MIT 
-ukkonen 1.0.1-py312h49ebfd2_4 (osx-64): MIT 
-ukkonen 1.0.1-py312h8572e83_4 (linux-64): MIT 
-ukkonen 1.0.1-py312h8f0b210_4 (linux-aarch64): MIT 
-urllib3 2.2.2-pyhd8ed1ab_1 (noarch): MIT 
-vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause 
-vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft 
-vc14_runtime 14.42.34438-hfd919c2_26 (win-64): LicenseRef-MicrosoftVisualCpp2015-2022Runtime 
-vhs 0.7.2-h57928b3_0 (win-64): MIT 
-vhs 0.7.2-h694c41f_0 (osx-64): MIT 
-vhs 0.7.2-h8af1aa0_0 (linux-aarch64): MIT 
-vhs 0.7.2-ha770c72_0 (linux-64): MIT 
-vhs 0.7.2-hce30654_0 (osx-arm64): MIT 
-virtualenv 20.26.3-pyhd8ed1ab_0 (noarch): MIT 
-vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause 
-vs2015_runtime 14.42.34438-h7142326_26 (win-64): BSD-3-Clause 
+taplo 0.9.1-h16c8c8b_0 (osx-arm64): MIT
+taplo 0.9.1-h1ff36dd_0 (linux-64): MIT
+taplo 0.9.1-h236d3af_0 (osx-64): MIT
+taplo 0.9.1-h7f3b576_0 (win-64): MIT
+taplo 0.9.1-hb8f9562_0 (linux-aarch64): MIT
+tk 8.6.13-h194ca79_0 (linux-aarch64): TCL
+tk 8.6.13-h1abcd95_1 (osx-64): TCL
+tk 8.6.13-h5083fa2_1 (osx-arm64): TCL
+tk 8.6.13-h5226925_1 (win-64): TCL
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tomli 2.0.1-pyhd8ed1ab_0 (noarch): MIT
+tqdm 4.66.4-pyhd8ed1ab_0 (noarch): MPL-2.0 or MIT
+truststore 0.8.0-pyhd8ed1ab_0 (noarch): MIT
+typos 1.22.7-h09b8157_0 (linux-aarch64): MIT
+typos 1.22.7-h686f776_0 (osx-64): MIT
+typos 1.22.7-h6e96688_0 (osx-arm64): MIT
+typos 1.22.7-h813c833_0 (win-64): MIT
+typos 1.22.7-he9194b0_0 (linux-64): MIT
+tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain
+ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary
+ukkonen 1.0.1-py312h0d7def4_4 (win-64): MIT
+ukkonen 1.0.1-py312h389731b_4 (osx-arm64): MIT
+ukkonen 1.0.1-py312h49ebfd2_4 (osx-64): MIT
+ukkonen 1.0.1-py312h8572e83_4 (linux-64): MIT
+ukkonen 1.0.1-py312h8f0b210_4 (linux-aarch64): MIT
+urllib3 2.2.2-pyhd8ed1ab_1 (noarch): MIT
+vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause
+vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft
+vc14_runtime 14.42.34438-hfd919c2_26 (win-64): LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+vhs 0.7.2-h57928b3_0 (win-64): MIT
+vhs 0.7.2-h694c41f_0 (osx-64): MIT
+vhs 0.7.2-h8af1aa0_0 (linux-aarch64): MIT
+vhs 0.7.2-ha770c72_0 (linux-64): MIT
+vhs 0.7.2-hce30654_0 (osx-arm64): MIT
+virtualenv 20.26.3-pyhd8ed1ab_0 (noarch): MIT
+vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause
+vs2015_runtime 14.42.34438-h7142326_26 (win-64): BSD-3-Clause
 win_inet_pton 1.1.0-pyhd8ed1ab_6 (noarch): PUBLIC-DOMAIN (Non-SPDX)
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h57fd34a_0 (osx-arm64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h775f41a_0 (osx-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h8d14728_0 (win-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h9cdd2b7_0 (linux-aarch64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
-yaml 0.2.5-h0d85af4_2 (osx-64): MIT 
-yaml 0.2.5-h3422bc3_2 (osx-arm64): MIT 
-yaml 0.2.5-h7f98852_2 (linux-64): MIT 
-yaml 0.2.5-h8ffe710_2 (win-64): MIT 
-yaml 0.2.5-hf897c2e_2 (linux-aarch64): MIT 
-yaml-cpp 0.8.0-h13dd4ca_0 (osx-arm64): MIT 
-yaml-cpp 0.8.0-h2f0025b_0 (linux-aarch64): MIT 
-yaml-cpp 0.8.0-h59595ed_0 (linux-64): MIT 
-yaml-cpp 0.8.0-h63175ca_0 (win-64): MIT 
-yaml-cpp 0.8.0-he965462_0 (osx-64): MIT 
-zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-zlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause 
-zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause 
-zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause 
-zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause 
-zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause 
-zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause 
-zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause 
+yaml 0.2.5-h0d85af4_2 (osx-64): MIT
+yaml 0.2.5-h3422bc3_2 (osx-arm64): MIT
+yaml 0.2.5-h7f98852_2 (linux-64): MIT
+yaml 0.2.5-h8ffe710_2 (win-64): MIT
+yaml 0.2.5-hf897c2e_2 (linux-aarch64): MIT
+yaml-cpp 0.8.0-h13dd4ca_0 (osx-arm64): MIT
+yaml-cpp 0.8.0-h2f0025b_0 (linux-aarch64): MIT
+yaml-cpp 0.8.0-h59595ed_0 (linux-64): MIT
+yaml-cpp 0.8.0-h63175ca_0 (win-64): MIT
+yaml-cpp 0.8.0-he965462_0 (osx-64): MIT
+zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+zlib 1.3.1-h87427d6_1 (osx-64): Zlib
+zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause
+zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause
+zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause
+zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause
+zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause
+zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause
+zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause
 zstd 1.5.6-hb46c0d2_0 (osx-arm64): BSD-3-Clause

--- a/tests/snapshots/integration_tests__list_test_default_use_case_pyproject.snap
+++ b/tests/snapshots/integration_tests__list_test_default_use_case_pyproject.snap
@@ -2,409 +2,409 @@
 source: tests/integration_tests.rs
 expression: stdout
 ---
-_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause 
-_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause 
+_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause
+_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause
 _sysroot_linux-aarch64_curr_repodata_hack 4-h57d6b7b_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-archspec 0.2.3-pyhd8ed1ab_0 (noarch): MIT OR Apache-2.0 
-binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only 
-binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only 
-binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only 
-binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only 
-binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause 
-binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause 
-boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-brotli-python 1.1.0-py312h2aa54b4_1 (linux-aarch64): MIT 
-brotli-python 1.1.0-py312h30efb56_1 (linux-64): MIT 
-brotli-python 1.1.0-py312h53d5487_1 (win-64): MIT 
-brotli-python 1.1.0-py312h9f69965_1 (osx-arm64): MIT 
-brotli-python 1.1.0-py312heafc425_1 (osx-64): MIT 
-bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6 
-bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6 
-bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6 
-bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6 
-bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6 
-c-ares 1.28.1-h10d778d_0 (osx-64): MIT 
-c-ares 1.28.1-h31becfc_0 (linux-aarch64): MIT 
-c-ares 1.28.1-h93a5062_0 (osx-arm64): MIT 
-c-ares 1.28.1-hd590300_0 (linux-64): MIT 
-c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause 
-c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause 
-ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC 
-ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC 
-ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC 
-ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC 
-ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC 
-certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC 
-cffi 1.16.0-py312h38bf5a0_0 (osx-64): MIT 
-cffi 1.16.0-py312h8e38eb3_0 (osx-arm64): MIT 
-cffi 1.16.0-py312he70551f_0 (win-64): MIT 
-cffi 1.16.0-py312hf06ca03_0 (linux-64): MIT 
-cffi 1.16.0-py312hf3c74c0_0 (linux-aarch64): MIT 
-cfgv 3.3.1-pyhd8ed1ab_0 (noarch): MIT 
-charset-normalizer 3.3.2-pyhd8ed1ab_0 (noarch): MIT 
-colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause 
-compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause 
-conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause 
-conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause 
-cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause 
-distlib 0.3.8-pyhd8ed1ab_0 (noarch): Apache-2.0 
-distro 1.9.0-pyhd8ed1ab_0 (noarch): Apache-2.0 
-filelock 3.15.4-pyhd8ed1ab_0 (noarch): Unlicense 
-fmt 10.2.1-h00ab1b0_0 (linux-64): MIT 
-fmt 10.2.1-h181d51b_0 (win-64): MIT 
-fmt 10.2.1-h2a328a1_0 (linux-aarch64): MIT 
-fmt 10.2.1-h2ffa867_0 (osx-arm64): MIT 
-fmt 10.2.1-h7728843_0 (osx-64): MIT 
-fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause 
-fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause 
-frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only 
-frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only 
-frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only 
-frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only 
-frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only 
-gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause 
-gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause 
-gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause 
-gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause 
-gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause 
-gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause 
-h2 4.1.0-pyhd8ed1ab_0 (noarch): MIT 
-hpack 4.0.0-pyh9f0ad1d_0 (noarch): MIT 
-hyperframe 6.0.1-pyhd8ed1ab_0 (noarch): MIT 
-icu 73.2-h59595ed_0 (linux-64): MIT 
-icu 73.2-h787c7f5_0 (linux-aarch64): MIT 
-icu 73.2-hc8870d7_0 (osx-arm64): MIT 
-icu 73.2-hf5e326d_0 (osx-64): MIT 
-identify 2.5.36-pyhd8ed1ab_0 (noarch): MIT 
-idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause 
-k9s 0.40.5-h36c15f3_1 (win-64): Apache-2.0 
-k9s 0.40.5-h87715bd_1 (osx-arm64): Apache-2.0 
-k9s 0.40.5-hc7f0b10_1 (osx-64): Apache-2.0 
-k9s 0.40.5-hd24410f_1 (linux-aarch64): Apache-2.0 
-k9s 0.40.5-he91c749_1 (linux-64): Apache-2.0 
+archspec 0.2.3-pyhd8ed1ab_0 (noarch): MIT OR Apache-2.0
+binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only
+binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only
+binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only
+binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only
+binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause
+binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause
+boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+brotli-python 1.1.0-py312h2aa54b4_1 (linux-aarch64): MIT
+brotli-python 1.1.0-py312h30efb56_1 (linux-64): MIT
+brotli-python 1.1.0-py312h53d5487_1 (win-64): MIT
+brotli-python 1.1.0-py312h9f69965_1 (osx-arm64): MIT
+brotli-python 1.1.0-py312heafc425_1 (osx-64): MIT
+bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6
+bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6
+bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6
+bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6
+bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6
+c-ares 1.28.1-h10d778d_0 (osx-64): MIT
+c-ares 1.28.1-h31becfc_0 (linux-aarch64): MIT
+c-ares 1.28.1-h93a5062_0 (osx-arm64): MIT
+c-ares 1.28.1-hd590300_0 (linux-64): MIT
+c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause
+c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause
+ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC
+ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC
+ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC
+ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC
+ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC
+certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC
+cffi 1.16.0-py312h38bf5a0_0 (osx-64): MIT
+cffi 1.16.0-py312h8e38eb3_0 (osx-arm64): MIT
+cffi 1.16.0-py312he70551f_0 (win-64): MIT
+cffi 1.16.0-py312hf06ca03_0 (linux-64): MIT
+cffi 1.16.0-py312hf3c74c0_0 (linux-aarch64): MIT
+cfgv 3.3.1-pyhd8ed1ab_0 (noarch): MIT
+charset-normalizer 3.3.2-pyhd8ed1ab_0 (noarch): MIT
+colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause
+compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause
+conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause
+conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause
+cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause
+distlib 0.3.8-pyhd8ed1ab_0 (noarch): Apache-2.0
+distro 1.9.0-pyhd8ed1ab_0 (noarch): Apache-2.0
+filelock 3.15.4-pyhd8ed1ab_0 (noarch): Unlicense
+fmt 10.2.1-h00ab1b0_0 (linux-64): MIT
+fmt 10.2.1-h181d51b_0 (win-64): MIT
+fmt 10.2.1-h2a328a1_0 (linux-aarch64): MIT
+fmt 10.2.1-h2ffa867_0 (osx-arm64): MIT
+fmt 10.2.1-h7728843_0 (osx-64): MIT
+fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause
+fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause
+frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only
+frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only
+frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only
+frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only
+frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only
+gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause
+gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause
+gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause
+gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause
+gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause
+gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause
+h2 4.1.0-pyhd8ed1ab_0 (noarch): MIT
+hpack 4.0.0-pyh9f0ad1d_0 (noarch): MIT
+hyperframe 6.0.1-pyhd8ed1ab_0 (noarch): MIT
+icu 73.2-h59595ed_0 (linux-64): MIT
+icu 73.2-h787c7f5_0 (linux-aarch64): MIT
+icu 73.2-hc8870d7_0 (osx-arm64): MIT
+icu 73.2-hf5e326d_0 (osx-64): MIT
+identify 2.5.36-pyhd8ed1ab_0 (noarch): MIT
+idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause
+k9s 0.40.5-h36c15f3_1 (win-64): Apache-2.0
+k9s 0.40.5-h87715bd_1 (osx-arm64): Apache-2.0
+k9s 0.40.5-hc7f0b10_1 (osx-64): Apache-2.0
+k9s 0.40.5-hd24410f_1 (linux-aarch64): Apache-2.0
+k9s 0.40.5-he91c749_1 (linux-64): Apache-2.0
 kernel-headers_linux-64 2.6.32-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 kernel-headers_linux-aarch64 4.18.0-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later 
-keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later 
-krb5 1.21.3-h237132a_0 (osx-arm64): MIT 
-krb5 1.21.3-h37d8d59_0 (osx-64): MIT 
-krb5 1.21.3-h50a48e9_0 (linux-aarch64): MIT 
-krb5 1.21.3-h659f571_0 (linux-64): MIT 
-krb5 1.21.3-hdf4eb48_0 (win-64): MIT 
-ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only 
-ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only 
-libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause 
-libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause 
-libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause 
-libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause 
-libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause 
-libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl 
-libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl 
-libcurl 8.8.0-hca28451_1 (linux-64): curl 
-libcurl 8.8.0-hd5e4a3a_1 (win-64): curl 
-libcurl 8.8.0-hf9fcc65_1 (osx-64): curl 
-libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception 
-libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause 
-libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause 
-libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause 
-libev 4.33-hd590300_2 (linux-64): BSD-2-Clause 
-libexpat 2.6.2-h2f0025b_0 (linux-aarch64): MIT 
-libexpat 2.6.2-h59595ed_0 (linux-64): MIT 
-libexpat 2.6.2-h63175ca_0 (win-64): MIT 
-libexpat 2.6.2-h73e2aa4_0 (osx-64): MIT 
-libexpat 2.6.2-hebf3989_0 (osx-arm64): MIT 
-libffi 3.4.2-h0d85af4_5 (osx-64): MIT 
-libffi 3.4.2-h3422bc3_5 (osx-arm64): MIT 
-libffi 3.4.2-h3557bc0_5 (linux-aarch64): MIT 
-libffi 3.4.2-h7f98852_5 (linux-64): MIT 
-libffi 3.4.2-h8ffe710_5 (win-64): MIT 
-libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later 
-libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later 
-libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only 
-libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only 
-libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only 
-libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only 
-libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only 
-libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later 
-libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later 
-libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause 
-libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause 
-libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause 
-libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause 
-libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause 
-libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause 
-libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause 
-libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause 
-libnghttp2 1.58.0-h47da74e_1 (linux-64): MIT 
-libnghttp2 1.58.0-h64cf6d3_1 (osx-64): MIT 
-libnghttp2 1.58.0-ha4dd798_1 (osx-arm64): MIT 
-libnghttp2 1.58.0-hb0e430d_1 (linux-aarch64): MIT 
-libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only 
-libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only 
-libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause 
-libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause 
-libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause 
-libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause 
-libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause 
-libsqlite 3.46.0-h1b8f9f3_0 (osx-64): Unlicense 
-libsqlite 3.46.0-h2466b09_0 (win-64): Unlicense 
-libsqlite 3.46.0-hde9e2c9_0 (linux-64): Unlicense 
-libsqlite 3.46.0-hf51ef55_0 (linux-aarch64): Unlicense 
-libsqlite 3.46.0-hfb93653_0 (osx-arm64): Unlicense 
-libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause 
-libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause 
-libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause 
-libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause 
-libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause 
-libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause 
-libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause 
-libuv 1.48.0-h31becfc_0 (linux-aarch64): MIT 
-libuv 1.48.0-h67532ce_0 (osx-64): MIT 
-libuv 1.48.0-h93a5062_0 (osx-arm64): MIT 
-libuv 1.48.0-hd590300_0 (linux-64): MIT 
-libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later 
-libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later 
-libxml2 2.12.7-h283a6d9_1 (win-64): MIT 
-libxml2 2.12.7-h3e169fe_1 (osx-64): MIT 
-libxml2 2.12.7-h49dc7a2_1 (linux-aarch64): MIT 
-libxml2 2.12.7-ha661575_1 (osx-arm64): MIT 
-libxml2 2.12.7-hc051c1a_1 (linux-64): MIT 
-libzlib 1.3.1-h2466b09_1 (win-64): Zlib 
-libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-libzlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause 
-lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause 
-lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause 
-lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause 
-lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause 
-lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later 
-lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later 
-lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later 
-lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later 
-lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later 
+keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later
+keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later
+krb5 1.21.3-h237132a_0 (osx-arm64): MIT
+krb5 1.21.3-h37d8d59_0 (osx-64): MIT
+krb5 1.21.3-h50a48e9_0 (linux-aarch64): MIT
+krb5 1.21.3-h659f571_0 (linux-64): MIT
+krb5 1.21.3-hdf4eb48_0 (win-64): MIT
+ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only
+ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only
+libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause
+libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause
+libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause
+libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause
+libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause
+libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl
+libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl
+libcurl 8.8.0-hca28451_1 (linux-64): curl
+libcurl 8.8.0-hd5e4a3a_1 (win-64): curl
+libcurl 8.8.0-hf9fcc65_1 (osx-64): curl
+libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception
+libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause
+libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause
+libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause
+libev 4.33-hd590300_2 (linux-64): BSD-2-Clause
+libexpat 2.6.2-h2f0025b_0 (linux-aarch64): MIT
+libexpat 2.6.2-h59595ed_0 (linux-64): MIT
+libexpat 2.6.2-h63175ca_0 (win-64): MIT
+libexpat 2.6.2-h73e2aa4_0 (osx-64): MIT
+libexpat 2.6.2-hebf3989_0 (osx-arm64): MIT
+libffi 3.4.2-h0d85af4_5 (osx-64): MIT
+libffi 3.4.2-h3422bc3_5 (osx-arm64): MIT
+libffi 3.4.2-h3557bc0_5 (linux-aarch64): MIT
+libffi 3.4.2-h7f98852_5 (linux-64): MIT
+libffi 3.4.2-h8ffe710_5 (win-64): MIT
+libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later
+libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later
+libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only
+libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only
+libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only
+libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only
+libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only
+libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later
+libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later
+libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause
+libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause
+libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause
+libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause
+libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause
+libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause
+libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause
+libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause
+libnghttp2 1.58.0-h47da74e_1 (linux-64): MIT
+libnghttp2 1.58.0-h64cf6d3_1 (osx-64): MIT
+libnghttp2 1.58.0-ha4dd798_1 (osx-arm64): MIT
+libnghttp2 1.58.0-hb0e430d_1 (linux-aarch64): MIT
+libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only
+libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only
+libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause
+libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause
+libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause
+libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause
+libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause
+libsqlite 3.46.0-h1b8f9f3_0 (osx-64): Unlicense
+libsqlite 3.46.0-h2466b09_0 (win-64): Unlicense
+libsqlite 3.46.0-hde9e2c9_0 (linux-64): Unlicense
+libsqlite 3.46.0-hf51ef55_0 (linux-aarch64): Unlicense
+libsqlite 3.46.0-hfb93653_0 (osx-arm64): Unlicense
+libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause
+libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause
+libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause
+libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause
+libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause
+libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause
+libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause
+libuv 1.48.0-h31becfc_0 (linux-aarch64): MIT
+libuv 1.48.0-h67532ce_0 (osx-64): MIT
+libuv 1.48.0-h93a5062_0 (osx-arm64): MIT
+libuv 1.48.0-hd590300_0 (linux-64): MIT
+libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later
+libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later
+libxml2 2.12.7-h283a6d9_1 (win-64): MIT
+libxml2 2.12.7-h3e169fe_1 (osx-64): MIT
+libxml2 2.12.7-h49dc7a2_1 (linux-aarch64): MIT
+libxml2 2.12.7-ha661575_1 (osx-arm64): MIT
+libxml2 2.12.7-hc051c1a_1 (linux-64): MIT
+libzlib 1.3.1-h2466b09_1 (win-64): Zlib
+libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+libzlib 1.3.1-h87427d6_1 (osx-64): Zlib
+libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause
+lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause
+lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause
+lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause
+lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause
+lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later
+lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later
+lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later
+lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later
+lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later
 m2w64-gcc-libgfortran 5.3.0-6 (win-64): GPL, LGPL, FDL, custom (Non-SPDX)
 m2w64-gcc-libs 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gcc-libs-core 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gmp 6.1.0-2 (win-64): LGPL3 (Non-SPDX)
 m2w64-libwinpthread-git 5.0.0.4634.697f757-2 (win-64): MIT, BSD (Non-SPDX)
-menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT 
-micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL 
-msys2-conda-epoch 20160418-1 (win-64): None (Non-SPDX)
-ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause 
-ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause 
-ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause 
-ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause 
-nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-nodejs 20.12.2-h3b52c9b_0 (osx-arm64): MIT 
-nodejs 20.12.2-h57928b3_0 (win-64): MIT 
-nodejs 20.12.2-hb753e55_0 (linux-64): MIT 
-nodejs 20.12.2-hc1f8a26_0 (linux-aarch64): MIT 
-nodejs 20.12.2-hfc0f20e_0 (osx-64): MIT 
-openssl 3.3.1-h2466b09_1 (win-64): Apache-2.0 
-openssl 3.3.1-h4ab18f5_1 (linux-64): Apache-2.0 
-openssl 3.3.1-h68df207_1 (linux-aarch64): Apache-2.0 
-openssl 3.3.1-h87427d6_1 (osx-64): Apache-2.0 
-openssl 3.3.1-hfb2fe0b_1 (osx-arm64): Apache-2.0 
-packaging 24.1-pyhd8ed1ab_0 (noarch): Apache-2.0 
-pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause 
-pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause 
-pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later 
-pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later 
-pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later 
-pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later 
-pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later 
-platformdirs 4.2.2-pyhd8ed1ab_0 (noarch): MIT 
-pluggy 1.5.0-pyhd8ed1ab_0 (noarch): MIT 
-pre-commit 3.7.1-pyha770c72_0 (noarch): MIT 
-pre-commit-hooks 4.6.0-pyhd8ed1ab_0 (noarch): MIT 
-prettier 3.3.2-h91d9761_0 (linux-64): MIT 
-prettier 3.3.2-hb408824_0 (osx-64): MIT 
-prettier 3.3.2-hb4d2b26_0 (win-64): MIT 
-prettier 3.3.2-hdbbef84_0 (linux-aarch64): MIT 
-prettier 3.3.2-he434342_0 (osx-arm64): MIT 
-pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause 
-pycosat 0.6.6-py312h02f2b3b_0 (osx-arm64): MIT 
-pycosat 0.6.6-py312h104f124_0 (osx-64): MIT 
-pycosat 0.6.6-py312h98912ed_0 (linux-64): MIT 
-pycosat 0.6.6-py312hdd3e373_0 (linux-aarch64): MIT 
-pycosat 0.6.6-py312he70551f_0 (win-64): MIT 
-pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause 
-python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0 
-python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0 
-python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0 
-python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0 
-python 3.12.4-h889d299_0_cpython (win-64): Python-2.0 
-python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (win-64): BSD-3-Clause 
-pyyaml 6.0.1-py312h02f2b3b_1 (osx-arm64): MIT 
-pyyaml 6.0.1-py312h104f124_1 (osx-64): MIT 
-pyyaml 6.0.1-py312h98912ed_1 (linux-64): MIT 
-pyyaml 6.0.1-py312hdd3e373_1 (linux-aarch64): MIT 
-pyyaml 6.0.1-py312he70551f_1 (win-64): MIT 
-readline 8.2-h8228510_1 (linux-64): GPL-3.0-only 
-readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only 
-readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only 
-readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only 
-reproc 14.2.4.post0-h10d778d_1 (osx-64): MIT 
-reproc 14.2.4.post0-h31becfc_1 (linux-aarch64): MIT 
-reproc 14.2.4.post0-h93a5062_1 (osx-arm64): MIT 
-reproc 14.2.4.post0-hcfcfb64_1 (win-64): MIT 
-reproc 14.2.4.post0-hd590300_1 (linux-64): MIT 
-reproc-cpp 14.2.4.post0-h2f0025b_1 (linux-aarch64): MIT 
-reproc-cpp 14.2.4.post0-h59595ed_1 (linux-64): MIT 
-reproc-cpp 14.2.4.post0-h63175ca_1 (win-64): MIT 
-reproc-cpp 14.2.4.post0-h93d8f39_1 (osx-64): MIT 
-reproc-cpp 14.2.4.post0-h965bd2d_1 (osx-arm64): MIT 
-requests 2.32.3-pyhd8ed1ab_0 (noarch): Apache-2.0 
-ruamel.yaml 0.18.6-py312h41838bb_0 (osx-64): MIT 
-ruamel.yaml 0.18.6-py312h98912ed_0 (linux-64): MIT 
-ruamel.yaml 0.18.6-py312hdd3e373_0 (linux-aarch64): MIT 
-ruamel.yaml 0.18.6-py312he37b823_0 (osx-arm64): MIT 
-ruamel.yaml 0.18.6-py312he70551f_0 (win-64): MIT 
-ruamel.yaml.clib 0.2.8-py312h41838bb_0 (osx-64): MIT 
-ruamel.yaml.clib 0.2.8-py312h98912ed_0 (linux-64): MIT 
-ruamel.yaml.clib 0.2.8-py312hdd3e373_0 (linux-aarch64): MIT 
-ruamel.yaml.clib 0.2.8-py312he37b823_0 (osx-arm64): MIT 
-ruamel.yaml.clib 0.2.8-py312he70551f_0 (win-64): MIT 
-rust 1.77.2-h4ff7c5d_1 (osx-arm64): MIT 
-rust 1.77.2-h70c747d_1 (linux-64): MIT 
-rust 1.77.2-h7e1429e_1 (osx-64): MIT 
-rust 1.77.2-h9d3d833_1 (linux-aarch64): MIT 
-rust 1.77.2-hf8d6059_1 (win-64): MIT 
-rust-std-aarch64-apple-darwin 1.77.2-hf6ec828_1 (noarch): MIT 
-rust-std-aarch64-unknown-linux-gnu 1.77.2-hbe8e118_1 (noarch): MIT 
-rust-std-x86_64-apple-darwin 1.77.2-h38e4360_1 (noarch): MIT 
-rust-std-x86_64-pc-windows-msvc 1.77.2-h17fc481_1 (noarch): MIT 
-rust-std-x86_64-unknown-linux-gnu 1.77.2-h2c6d0dc_1 (noarch): MIT 
-setuptools 70.1.1-pyhd8ed1ab_0 (noarch): MIT 
+menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT
+micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL
+msys2-conda-epoch 20160418-1 (win-64): no license
+ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause
+ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause
+ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause
+ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause
+nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+nodejs 20.12.2-h3b52c9b_0 (osx-arm64): MIT
+nodejs 20.12.2-h57928b3_0 (win-64): MIT
+nodejs 20.12.2-hb753e55_0 (linux-64): MIT
+nodejs 20.12.2-hc1f8a26_0 (linux-aarch64): MIT
+nodejs 20.12.2-hfc0f20e_0 (osx-64): MIT
+openssl 3.3.1-h2466b09_1 (win-64): Apache-2.0
+openssl 3.3.1-h4ab18f5_1 (linux-64): Apache-2.0
+openssl 3.3.1-h68df207_1 (linux-aarch64): Apache-2.0
+openssl 3.3.1-h87427d6_1 (osx-64): Apache-2.0
+openssl 3.3.1-hfb2fe0b_1 (osx-arm64): Apache-2.0
+packaging 24.1-pyhd8ed1ab_0 (noarch): Apache-2.0
+pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause
+pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause
+pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later
+pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later
+pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later
+pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later
+pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later
+platformdirs 4.2.2-pyhd8ed1ab_0 (noarch): MIT
+pluggy 1.5.0-pyhd8ed1ab_0 (noarch): MIT
+pre-commit 3.7.1-pyha770c72_0 (noarch): MIT
+pre-commit-hooks 4.6.0-pyhd8ed1ab_0 (noarch): MIT
+prettier 3.3.2-h91d9761_0 (linux-64): MIT
+prettier 3.3.2-hb408824_0 (osx-64): MIT
+prettier 3.3.2-hb4d2b26_0 (win-64): MIT
+prettier 3.3.2-hdbbef84_0 (linux-aarch64): MIT
+prettier 3.3.2-he434342_0 (osx-arm64): MIT
+pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause
+pycosat 0.6.6-py312h02f2b3b_0 (osx-arm64): MIT
+pycosat 0.6.6-py312h104f124_0 (osx-64): MIT
+pycosat 0.6.6-py312h98912ed_0 (linux-64): MIT
+pycosat 0.6.6-py312hdd3e373_0 (linux-aarch64): MIT
+pycosat 0.6.6-py312he70551f_0 (win-64): MIT
+pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause
+python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0
+python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0
+python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0
+python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0
+python 3.12.4-h889d299_0_cpython (win-64): Python-2.0
+python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause
+python_abi 3.12-4_cp312 (win-64): BSD-3-Clause
+pyyaml 6.0.1-py312h02f2b3b_1 (osx-arm64): MIT
+pyyaml 6.0.1-py312h104f124_1 (osx-64): MIT
+pyyaml 6.0.1-py312h98912ed_1 (linux-64): MIT
+pyyaml 6.0.1-py312hdd3e373_1 (linux-aarch64): MIT
+pyyaml 6.0.1-py312he70551f_1 (win-64): MIT
+readline 8.2-h8228510_1 (linux-64): GPL-3.0-only
+readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only
+readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only
+readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only
+reproc 14.2.4.post0-h10d778d_1 (osx-64): MIT
+reproc 14.2.4.post0-h31becfc_1 (linux-aarch64): MIT
+reproc 14.2.4.post0-h93a5062_1 (osx-arm64): MIT
+reproc 14.2.4.post0-hcfcfb64_1 (win-64): MIT
+reproc 14.2.4.post0-hd590300_1 (linux-64): MIT
+reproc-cpp 14.2.4.post0-h2f0025b_1 (linux-aarch64): MIT
+reproc-cpp 14.2.4.post0-h59595ed_1 (linux-64): MIT
+reproc-cpp 14.2.4.post0-h63175ca_1 (win-64): MIT
+reproc-cpp 14.2.4.post0-h93d8f39_1 (osx-64): MIT
+reproc-cpp 14.2.4.post0-h965bd2d_1 (osx-arm64): MIT
+requests 2.32.3-pyhd8ed1ab_0 (noarch): Apache-2.0
+ruamel.yaml 0.18.6-py312h41838bb_0 (osx-64): MIT
+ruamel.yaml 0.18.6-py312h98912ed_0 (linux-64): MIT
+ruamel.yaml 0.18.6-py312hdd3e373_0 (linux-aarch64): MIT
+ruamel.yaml 0.18.6-py312he37b823_0 (osx-arm64): MIT
+ruamel.yaml 0.18.6-py312he70551f_0 (win-64): MIT
+ruamel.yaml.clib 0.2.8-py312h41838bb_0 (osx-64): MIT
+ruamel.yaml.clib 0.2.8-py312h98912ed_0 (linux-64): MIT
+ruamel.yaml.clib 0.2.8-py312hdd3e373_0 (linux-aarch64): MIT
+ruamel.yaml.clib 0.2.8-py312he37b823_0 (osx-arm64): MIT
+ruamel.yaml.clib 0.2.8-py312he70551f_0 (win-64): MIT
+rust 1.77.2-h4ff7c5d_1 (osx-arm64): MIT
+rust 1.77.2-h70c747d_1 (linux-64): MIT
+rust 1.77.2-h7e1429e_1 (osx-64): MIT
+rust 1.77.2-h9d3d833_1 (linux-aarch64): MIT
+rust 1.77.2-hf8d6059_1 (win-64): MIT
+rust-std-aarch64-apple-darwin 1.77.2-hf6ec828_1 (noarch): MIT
+rust-std-aarch64-unknown-linux-gnu 1.77.2-hbe8e118_1 (noarch): MIT
+rust-std-x86_64-apple-darwin 1.77.2-h38e4360_1 (noarch): MIT
+rust-std-x86_64-pc-windows-msvc 1.77.2-h17fc481_1 (noarch): MIT
+rust-std-x86_64-unknown-linux-gnu 1.77.2-h2c6d0dc_1 (noarch): MIT
+setuptools 70.1.1-pyhd8ed1ab_0 (noarch): MIT
 sysroot_linux-64 2.12-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 sysroot_linux-aarch64 2.17-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-taplo 0.9.1-h16c8c8b_0 (osx-arm64): MIT 
-taplo 0.9.1-h1ff36dd_0 (linux-64): MIT 
-taplo 0.9.1-h236d3af_0 (osx-64): MIT 
-taplo 0.9.1-h7f3b576_0 (win-64): MIT 
-taplo 0.9.1-hb8f9562_0 (linux-aarch64): MIT 
-tk 8.6.13-h194ca79_0 (linux-aarch64): TCL 
-tk 8.6.13-h1abcd95_1 (osx-64): TCL 
-tk 8.6.13-h5083fa2_1 (osx-arm64): TCL 
-tk 8.6.13-h5226925_1 (win-64): TCL 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tomli 2.0.1-pyhd8ed1ab_0 (noarch): MIT 
-tqdm 4.66.4-pyhd8ed1ab_0 (noarch): MPL-2.0 or MIT 
-truststore 0.8.0-pyhd8ed1ab_0 (noarch): MIT 
-typos 1.22.7-h09b8157_0 (linux-aarch64): MIT 
-typos 1.22.7-h686f776_0 (osx-64): MIT 
-typos 1.22.7-h6e96688_0 (osx-arm64): MIT 
-typos 1.22.7-h813c833_0 (win-64): MIT 
-typos 1.22.7-he9194b0_0 (linux-64): MIT 
-tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain 
-ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary 
-ukkonen 1.0.1-py312h0d7def4_4 (win-64): MIT 
-ukkonen 1.0.1-py312h389731b_4 (osx-arm64): MIT 
-ukkonen 1.0.1-py312h49ebfd2_4 (osx-64): MIT 
-ukkonen 1.0.1-py312h8572e83_4 (linux-64): MIT 
-ukkonen 1.0.1-py312h8f0b210_4 (linux-aarch64): MIT 
-urllib3 2.2.2-pyhd8ed1ab_1 (noarch): MIT 
-vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause 
-vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft 
-vc14_runtime 14.42.34438-hfd919c2_26 (win-64): LicenseRef-MicrosoftVisualCpp2015-2022Runtime 
-vhs 0.7.2-h57928b3_0 (win-64): MIT 
-vhs 0.7.2-h694c41f_0 (osx-64): MIT 
-vhs 0.7.2-h8af1aa0_0 (linux-aarch64): MIT 
-vhs 0.7.2-ha770c72_0 (linux-64): MIT 
-vhs 0.7.2-hce30654_0 (osx-arm64): MIT 
-virtualenv 20.26.3-pyhd8ed1ab_0 (noarch): MIT 
-vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause 
-vs2015_runtime 14.42.34438-h7142326_26 (win-64): BSD-3-Clause 
+taplo 0.9.1-h16c8c8b_0 (osx-arm64): MIT
+taplo 0.9.1-h1ff36dd_0 (linux-64): MIT
+taplo 0.9.1-h236d3af_0 (osx-64): MIT
+taplo 0.9.1-h7f3b576_0 (win-64): MIT
+taplo 0.9.1-hb8f9562_0 (linux-aarch64): MIT
+tk 8.6.13-h194ca79_0 (linux-aarch64): TCL
+tk 8.6.13-h1abcd95_1 (osx-64): TCL
+tk 8.6.13-h5083fa2_1 (osx-arm64): TCL
+tk 8.6.13-h5226925_1 (win-64): TCL
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tomli 2.0.1-pyhd8ed1ab_0 (noarch): MIT
+tqdm 4.66.4-pyhd8ed1ab_0 (noarch): MPL-2.0 or MIT
+truststore 0.8.0-pyhd8ed1ab_0 (noarch): MIT
+typos 1.22.7-h09b8157_0 (linux-aarch64): MIT
+typos 1.22.7-h686f776_0 (osx-64): MIT
+typos 1.22.7-h6e96688_0 (osx-arm64): MIT
+typos 1.22.7-h813c833_0 (win-64): MIT
+typos 1.22.7-he9194b0_0 (linux-64): MIT
+tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain
+ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary
+ukkonen 1.0.1-py312h0d7def4_4 (win-64): MIT
+ukkonen 1.0.1-py312h389731b_4 (osx-arm64): MIT
+ukkonen 1.0.1-py312h49ebfd2_4 (osx-64): MIT
+ukkonen 1.0.1-py312h8572e83_4 (linux-64): MIT
+ukkonen 1.0.1-py312h8f0b210_4 (linux-aarch64): MIT
+urllib3 2.2.2-pyhd8ed1ab_1 (noarch): MIT
+vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause
+vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft
+vc14_runtime 14.42.34438-hfd919c2_26 (win-64): LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+vhs 0.7.2-h57928b3_0 (win-64): MIT
+vhs 0.7.2-h694c41f_0 (osx-64): MIT
+vhs 0.7.2-h8af1aa0_0 (linux-aarch64): MIT
+vhs 0.7.2-ha770c72_0 (linux-64): MIT
+vhs 0.7.2-hce30654_0 (osx-arm64): MIT
+virtualenv 20.26.3-pyhd8ed1ab_0 (noarch): MIT
+vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause
+vs2015_runtime 14.42.34438-h7142326_26 (win-64): BSD-3-Clause
 win_inet_pton 1.1.0-pyhd8ed1ab_6 (noarch): PUBLIC-DOMAIN (Non-SPDX)
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h57fd34a_0 (osx-arm64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h775f41a_0 (osx-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h8d14728_0 (win-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h9cdd2b7_0 (linux-aarch64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
-yaml 0.2.5-h0d85af4_2 (osx-64): MIT 
-yaml 0.2.5-h3422bc3_2 (osx-arm64): MIT 
-yaml 0.2.5-h7f98852_2 (linux-64): MIT 
-yaml 0.2.5-h8ffe710_2 (win-64): MIT 
-yaml 0.2.5-hf897c2e_2 (linux-aarch64): MIT 
-yaml-cpp 0.8.0-h13dd4ca_0 (osx-arm64): MIT 
-yaml-cpp 0.8.0-h2f0025b_0 (linux-aarch64): MIT 
-yaml-cpp 0.8.0-h59595ed_0 (linux-64): MIT 
-yaml-cpp 0.8.0-h63175ca_0 (win-64): MIT 
-yaml-cpp 0.8.0-he965462_0 (osx-64): MIT 
-zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-zlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause 
-zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause 
-zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause 
-zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause 
-zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause 
-zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause 
-zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause 
+yaml 0.2.5-h0d85af4_2 (osx-64): MIT
+yaml 0.2.5-h3422bc3_2 (osx-arm64): MIT
+yaml 0.2.5-h7f98852_2 (linux-64): MIT
+yaml 0.2.5-h8ffe710_2 (win-64): MIT
+yaml 0.2.5-hf897c2e_2 (linux-aarch64): MIT
+yaml-cpp 0.8.0-h13dd4ca_0 (osx-arm64): MIT
+yaml-cpp 0.8.0-h2f0025b_0 (linux-aarch64): MIT
+yaml-cpp 0.8.0-h59595ed_0 (linux-64): MIT
+yaml-cpp 0.8.0-h63175ca_0 (win-64): MIT
+yaml-cpp 0.8.0-he965462_0 (osx-64): MIT
+zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+zlib 1.3.1-h87427d6_1 (osx-64): Zlib
+zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause
+zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause
+zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause
+zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause
+zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause
+zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause
+zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause
 zstd 1.5.6-hb46c0d2_0 (osx-arm64): BSD-3-Clause

--- a/tests/snapshots/integration_tests__local_allowlist_check.snap
+++ b/tests/snapshots/integration_tests__local_allowlist_check.snap
@@ -5,242 +5,242 @@ expression: output
 
 ❌ The following dependencies are unsafe:
 
-_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause 
-_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause 
+_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause
+_openmp_mutex 4.5-2_gnu (linux-aarch64): BSD-3-Clause
 _sysroot_linux-aarch64_curr_repodata_hack 4-h57d6b7b_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only 
-binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only 
-binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only 
-binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only 
-binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause 
-binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause 
-boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6 
-bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6 
-bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6 
-bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6 
-bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6 
-c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause 
-c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause 
-ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC 
-ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC 
-ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC 
-ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC 
-ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC 
-certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC 
-colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause 
-compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause 
-conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause 
-conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause 
-cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause 
-fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause 
-fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause 
-frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only 
-frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only 
-frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only 
-frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only 
-frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only 
-gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause 
-gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause 
-gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause 
-gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause 
-gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause 
-gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause 
-gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause 
-gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause 
-idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause 
-jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause 
-jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause 
+binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only
+binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only
+binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only
+binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only
+binutils_linux-64 2.40-hb3c18ed_9 (linux-64): BSD-3-Clause
+binutils_linux-aarch64 2.40-h1f91aba_9 (linux-aarch64): BSD-3-Clause
+boltons 24.0.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6
+bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6
+bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6
+bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6
+bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6
+c-compiler 1.7.0-h31becfc_1 (linux-aarch64): BSD-3-Clause
+c-compiler 1.7.0-hd590300_1 (linux-64): BSD-3-Clause
+ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC
+ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC
+ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC
+ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC
+ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC
+certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC
+colorama 0.4.6-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+compilers 1.7.0-h8af1aa0_1 (linux-aarch64): BSD-3-Clause
+compilers 1.7.0-ha770c72_1 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+conda 24.5.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+conda 24.5.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+conda 24.5.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+conda 24.5.0-py312hb401068_0 (osx-64): BSD-3-Clause
+conda-libmamba-solver 24.1.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+conda-package-handling 2.3.0-pyh7900ff3_0 (noarch): BSD-3-Clause
+conda-package-streaming 0.10.0-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+cxx-compiler 1.7.0-h00ab1b0_1 (linux-64): BSD-3-Clause
+cxx-compiler 1.7.0-h2a328a1_1 (linux-aarch64): BSD-3-Clause
+fortran-compiler 1.7.0-h7048d53_1 (linux-aarch64): BSD-3-Clause
+fortran-compiler 1.7.0-heb67821_1 (linux-64): BSD-3-Clause
+frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only
+frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only
+frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only
+frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only
+frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only
+gcc 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gcc 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_linux-64 12.3.0-h9528a6a_9 (linux-64): BSD-3-Clause
+gcc_linux-aarch64 12.3.0-ha52a6ea_9 (linux-aarch64): BSD-3-Clause
+gfortran 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gfortran 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_linux-64 12.3.0-h5877db1_9 (linux-64): BSD-3-Clause
+gfortran_linux-aarch64 12.3.0-ha7b8e4b_9 (linux-aarch64): BSD-3-Clause
+gxx 12.3.0-h915e2ae_13 (linux-64): BSD-3-Clause
+gxx 12.3.0-hdb0cc85_13 (linux-aarch64): BSD-3-Clause
+gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_linux-64 12.3.0-ha28b414_9 (linux-64): BSD-3-Clause
+gxx_linux-aarch64 12.3.0-h9d1f256_9 (linux-aarch64): BSD-3-Clause
+idna 3.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpatch 1.33-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+jsonpointer 3.0.0-py312h2e8e312_0 (win-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h7900ff3_0 (linux-64): BSD-3-Clause
+jsonpointer 3.0.0-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause
+jsonpointer 3.0.0-py312h996f985_0 (linux-aarch64): BSD-3-Clause
+jsonpointer 3.0.0-py312hb401068_0 (osx-64): BSD-3-Clause
 kernel-headers_linux-64 2.6.32-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 kernel-headers_linux-aarch64 4.18.0-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later 
-keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later 
-ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only 
-ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only 
-libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause 
-libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause 
-libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause 
-libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause 
-libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause 
-libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl 
-libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl 
-libcurl 8.8.0-hca28451_1 (linux-64): curl 
-libcurl 8.8.0-hd5e4a3a_1 (win-64): curl 
-libcurl 8.8.0-hf9fcc65_1 (osx-64): curl 
-libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception 
-libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause 
-libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause 
-libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause 
-libev 4.33-hd590300_2 (linux-64): BSD-2-Clause 
-libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later 
-libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later 
-libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only 
-libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only 
-libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only 
-libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only 
-libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only 
-libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later 
-libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later 
-libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause 
-libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause 
-libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause 
-libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause 
-libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause 
-libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause 
-libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause 
-libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause 
-libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause 
-libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only 
-libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only 
-libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause 
-libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause 
-libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause 
-libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause 
-libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause 
-libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause 
-libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause 
-libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause 
-libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause 
-libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause 
-libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause 
-libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause 
-libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later 
-libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later 
-libzlib 1.3.1-h2466b09_1 (win-64): Zlib 
-libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-libzlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause 
-lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause 
-lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause 
-lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause 
-lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause 
-lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later 
-lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later 
-lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later 
-lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later 
-lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later 
+keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later
+keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later
+ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only
+ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only
+libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause
+libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause
+libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause
+libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause
+libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause
+libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl
+libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl
+libcurl 8.8.0-hca28451_1 (linux-64): curl
+libcurl 8.8.0-hd5e4a3a_1 (win-64): curl
+libcurl 8.8.0-hf9fcc65_1 (osx-64): curl
+libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception
+libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause
+libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause
+libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause
+libev 4.33-hd590300_2 (linux-64): BSD-2-Clause
+libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later
+libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later
+libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only
+libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only
+libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only
+libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only
+libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only
+libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later
+libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later
+libmamba 1.5.8-h3f09ed1_0 (win-64): BSD-3-Clause
+libmamba 1.5.8-h90c426b_0 (osx-arm64): BSD-3-Clause
+libmamba 1.5.8-ha449628_0 (osx-64): BSD-3-Clause
+libmamba 1.5.8-had39da4_0 (linux-64): BSD-3-Clause
+libmamba 1.5.8-hea3be6c_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h1e39527_0 (linux-aarch64): BSD-3-Clause
+libmambapy 1.5.8-py312h344e357_0 (osx-arm64): BSD-3-Clause
+libmambapy 1.5.8-py312h66cf91f_0 (win-64): BSD-3-Clause
+libmambapy 1.5.8-py312h67f5953_0 (osx-64): BSD-3-Clause
+libmambapy 1.5.8-py312hd9e9ff6_0 (linux-64): BSD-3-Clause
+libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only
+libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only
+libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libsolv 0.7.29-h0ea2cb4_0 (win-64): BSD-3-Clause
+libsolv 0.7.29-h1efcc80_0 (osx-arm64): BSD-3-Clause
+libsolv 0.7.29-h332ec48_0 (linux-aarch64): BSD-3-Clause
+libsolv 0.7.29-h4f92f52_0 (osx-64): BSD-3-Clause
+libsolv 0.7.29-ha6fb4c9_0 (linux-64): BSD-3-Clause
+libssh2 1.11.0-h0841786_0 (linux-64): BSD-3-Clause
+libssh2 1.11.0-h492db2e_0 (linux-aarch64): BSD-3-Clause
+libssh2 1.11.0-h7a5bd25_0 (osx-arm64): BSD-3-Clause
+libssh2 1.11.0-h7dfc565_0 (win-64): BSD-3-Clause
+libssh2 1.11.0-hd019ec5_0 (osx-64): BSD-3-Clause
+libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause
+libuuid 2.38.1-hb4cce97_0 (linux-aarch64): BSD-3-Clause
+libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later
+libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later
+libzlib 1.3.1-h2466b09_1 (win-64): Zlib
+libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+libzlib 1.3.1-h87427d6_1 (osx-64): Zlib
+libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause
+lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause
+lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause
+lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause
+lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause
+lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later
+lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later
+lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later
+lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later
+lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later
 m2w64-gcc-libgfortran 5.3.0-6 (win-64): GPL, LGPL, FDL, custom (Non-SPDX)
 m2w64-gcc-libs 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gcc-libs-core 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gmp 6.1.0-2 (win-64): LGPL3 (Non-SPDX)
 m2w64-libwinpthread-git 5.0.0.4634.697f757-2 (win-64): MIT, BSD (Non-SPDX)
-menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT 
-menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT 
-micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL 
-msys2-conda-epoch 20160418-1 (win-64): None (Non-SPDX)
-ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause 
-ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause 
-ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause 
-ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause 
-nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause 
-pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause 
-pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later 
-pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later 
-pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later 
-pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later 
-pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later 
-pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause 
-pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause 
-pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause 
-python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0 
-python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0 
-python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0 
-python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0 
-python 3.12.4-h889d299_0_cpython (win-64): Python-2.0 
-python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause 
-python_abi 3.12-4_cp312 (win-64): BSD-3-Clause 
-readline 8.2-h8228510_1 (linux-64): GPL-3.0-only 
-readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only 
-readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only 
-readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only 
+menuinst 2.1.1-py312h275cf98_0 (win-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h7900ff3_0 (linux-64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h81bd7bf_0 (osx-arm64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312h996f985_0 (linux-aarch64): BSD-3-Clause AND MIT
+menuinst 2.1.1-py312hb401068_0 (osx-64): BSD-3-Clause AND MIT
+micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL
+msys2-conda-epoch 20160418-1 (win-64): no license
+ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause
+ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause
+ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause
+ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause
+nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+pcre2 10.44-h297a79d_0 (osx-arm64): BSD-3-Clause
+pcre2 10.44-h3d7b363_0 (win-64): BSD-3-Clause
+pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later
+pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later
+pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later
+pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later
+pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later
+pybind11-abi 4-hd8ed1ab_3 (noarch): BSD-3-Clause
+pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyh0701188_6 (noarch): BSD-3-Clause
+pysocks 1.7.1-pyha2e5f31_6 (noarch): BSD-3-Clause
+python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0
+python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0
+python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0
+python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0
+python 3.12.4-h889d299_0_cpython (win-64): Python-2.0
+python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (linux-aarch64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-64): BSD-3-Clause
+python_abi 3.12-4_cp312 (osx-arm64): BSD-3-Clause
+python_abi 3.12-4_cp312 (win-64): BSD-3-Clause
+readline 8.2-h8228510_1 (linux-64): GPL-3.0-only
+readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only
+readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only
+readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only
 sysroot_linux-64 2.12-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 sysroot_linux-aarch64 2.17-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-tk 8.6.13-h194ca79_0 (linux-aarch64): TCL 
-tk 8.6.13-h1abcd95_1 (osx-64): TCL 
-tk 8.6.13-h5083fa2_1 (osx-arm64): TCL 
-tk 8.6.13-h5226925_1 (win-64): TCL 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain 
-ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary 
-vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause 
-vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft 
-vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause 
+tk 8.6.13-h194ca79_0 (linux-aarch64): TCL
+tk 8.6.13-h1abcd95_1 (osx-64): TCL
+tk 8.6.13-h5083fa2_1 (osx-arm64): TCL
+tk 8.6.13-h5226925_1 (win-64): TCL
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain
+ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary
+vc 14.3-h8a93ad2_20 (win-64): BSD-3-Clause
+vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft
+vs2015_runtime 14.40.33810-h3bf8584_20 (win-64): BSD-3-Clause
 win_inet_pton 1.1.0-pyhd8ed1ab_6 (noarch): PUBLIC-DOMAIN (Non-SPDX)
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h57fd34a_0 (osx-arm64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h775f41a_0 (osx-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h8d14728_0 (win-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h9cdd2b7_0 (linux-aarch64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
-zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-zlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause 
-zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause 
-zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause 
-zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause 
-zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause 
-zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause 
-zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause 
-zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause 
-zstd 1.5.6-hb46c0d2_0 (osx-arm64): BSD-3-Clause 
+zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+zlib 1.3.1-h87427d6_1 (osx-64): Zlib
+zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+zstandard 0.22.0-py312h331e495_1 (osx-64): BSD-3-Clause
+zstandard 0.22.0-py312h5b18bf6_1 (linux-64): BSD-3-Clause
+zstandard 0.22.0-py312h721a963_1 (osx-arm64): BSD-3-Clause
+zstandard 0.22.0-py312h7606c53_1 (win-64): BSD-3-Clause
+zstandard 0.22.0-py312h9fc3309_1 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h02f22dd_0 (linux-aarch64): BSD-3-Clause
+zstd 1.5.6-h0ea2cb4_0 (win-64): BSD-3-Clause
+zstd 1.5.6-h915ae27_0 (osx-64): BSD-3-Clause
+zstd 1.5.6-ha6fb4c9_0 (linux-64): BSD-3-Clause
+zstd 1.5.6-hb46c0d2_0 (osx-arm64): BSD-3-Clause
 
 ❌ Unsafe licenses found! ❌
 There were 163 safe licenses and 236 unsafe licenses.

--- a/tests/snapshots/integration_tests__multiple_allowlists_check.snap
+++ b/tests/snapshots/integration_tests__multiple_allowlists_check.snap
@@ -6,149 +6,149 @@ expression: output
 ❌ The following dependencies are unsafe:
 
 _sysroot_linux-aarch64_curr_repodata_hack 4-h57d6b7b_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only 
-binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only 
-binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only 
-binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only 
-bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6 
-bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6 
-bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6 
-bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6 
-bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6 
-ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC 
-ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC 
-ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC 
-ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC 
-ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC 
-certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC 
-frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only 
-frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only 
-frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only 
-frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only 
-frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only 
-gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
+binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only
+binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only
+binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only
+binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only
+bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6
+bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6
+bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6
+bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6
+bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6
+ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC
+ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC
+ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC
+ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC
+ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC
+certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC
+frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only
+frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only
+frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only
+frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only
+frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only
+gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
 kernel-headers_linux-64 2.6.32-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 kernel-headers_linux-aarch64 4.18.0-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later 
-keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later 
-ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only 
-ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only 
-libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause 
-libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause 
-libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause 
-libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause 
-libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause 
-libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl 
-libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl 
-libcurl 8.8.0-hca28451_1 (linux-64): curl 
-libcurl 8.8.0-hd5e4a3a_1 (win-64): curl 
-libcurl 8.8.0-hf9fcc65_1 (osx-64): curl 
-libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception 
-libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause 
-libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause 
-libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause 
-libev 4.33-hd590300_2 (linux-64): BSD-2-Clause 
-libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later 
-libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later 
-libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only 
-libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only 
-libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only 
-libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only 
-libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only 
-libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later 
-libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later 
-libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only 
-libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only 
-libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later 
-libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later 
-libzlib 1.3.1-h2466b09_1 (win-64): Zlib 
-libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-libzlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause 
-lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause 
-lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause 
-lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause 
-lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause 
-lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later 
-lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later 
-lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later 
-lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later 
-lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later 
+keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later
+keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later
+ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only
+ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only
+libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause
+libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause
+libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause
+libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause
+libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause
+libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl
+libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl
+libcurl 8.8.0-hca28451_1 (linux-64): curl
+libcurl 8.8.0-hd5e4a3a_1 (win-64): curl
+libcurl 8.8.0-hf9fcc65_1 (osx-64): curl
+libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception
+libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause
+libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause
+libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause
+libev 4.33-hd590300_2 (linux-64): BSD-2-Clause
+libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later
+libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later
+libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only
+libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only
+libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only
+libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only
+libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only
+libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later
+libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later
+libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only
+libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only
+libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later
+libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later
+libzlib 1.3.1-h2466b09_1 (win-64): Zlib
+libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+libzlib 1.3.1-h87427d6_1 (osx-64): Zlib
+libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause
+lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause
+lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause
+lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause
+lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause
+lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later
+lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later
+lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later
+lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later
+lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later
 m2w64-gcc-libgfortran 5.3.0-6 (win-64): GPL, LGPL, FDL, custom (Non-SPDX)
 m2w64-gcc-libs 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gcc-libs-core 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gmp 6.1.0-2 (win-64): LGPL3 (Non-SPDX)
 m2w64-libwinpthread-git 5.0.0.4634.697f757-2 (win-64): MIT, BSD (Non-SPDX)
-micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL 
-msys2-conda-epoch 20160418-1 (win-64): None (Non-SPDX)
-ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause 
-ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause 
-ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause 
-ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause 
-pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later 
-pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later 
-pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later 
-pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later 
-pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later 
-python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0 
-python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0 
-python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0 
-python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0 
-python 3.12.4-h889d299_0_cpython (win-64): Python-2.0 
-readline 8.2-h8228510_1 (linux-64): GPL-3.0-only 
-readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only 
-readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only 
-readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only 
+micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL
+msys2-conda-epoch 20160418-1 (win-64): no license
+ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause
+ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause
+ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause
+ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause
+pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later
+pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later
+pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later
+pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later
+pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later
+python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0
+python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0
+python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0
+python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0
+python 3.12.4-h889d299_0_cpython (win-64): Python-2.0
+readline 8.2-h8228510_1 (linux-64): GPL-3.0-only
+readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only
+readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only
+readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only
 sysroot_linux-64 2.12-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 sysroot_linux-aarch64 2.17-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-tk 8.6.13-h194ca79_0 (linux-aarch64): TCL 
-tk 8.6.13-h1abcd95_1 (osx-64): TCL 
-tk 8.6.13-h5083fa2_1 (osx-arm64): TCL 
-tk 8.6.13-h5226925_1 (win-64): TCL 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain 
-ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary 
-vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft 
+tk 8.6.13-h194ca79_0 (linux-aarch64): TCL
+tk 8.6.13-h1abcd95_1 (osx-64): TCL
+tk 8.6.13-h5083fa2_1 (osx-arm64): TCL
+tk 8.6.13-h5226925_1 (win-64): TCL
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain
+ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary
+vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft
 win_inet_pton 1.1.0-pyhd8ed1ab_6 (noarch): PUBLIC-DOMAIN (Non-SPDX)
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h57fd34a_0 (osx-arm64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h775f41a_0 (osx-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h8d14728_0 (win-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h9cdd2b7_0 (linux-aarch64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
-zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-zlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
+zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+zlib 1.3.1-h87427d6_1 (osx-64): Zlib
+zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
 
 ❌ Unsafe licenses found! ❌
 There were 255 safe licenses and 144 unsafe licenses.

--- a/tests/snapshots/integration_tests__osi_check.snap
+++ b/tests/snapshots/integration_tests__osi_check.snap
@@ -7,65 +7,65 @@ expression: output
 
 _libgcc_mutex 0.1-conda_forge (linux-64): None (Non-SPDX)
 _sysroot_linux-aarch64_curr_repodata_hack 4-h57d6b7b_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6 
-bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6 
-bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6 
-bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6 
-bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6 
-gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
+bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6
+bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6
+bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6
+bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6
+bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6
+gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
 kernel-headers_linux-64 2.6.32-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 kernel-headers_linux-aarch64 4.18.0-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl 
-libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl 
-libcurl 8.8.0-hca28451_1 (linux-64): curl 
-libcurl 8.8.0-hd5e4a3a_1 (win-64): curl 
-libcurl 8.8.0-hf9fcc65_1 (osx-64): curl 
-libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception 
-libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
+libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl
+libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl
+libcurl 8.8.0-hca28451_1 (linux-64): curl
+libcurl 8.8.0-hd5e4a3a_1 (win-64): curl
+libcurl 8.8.0-hf9fcc65_1 (osx-64): curl
+libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception
+libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
 m2w64-gcc-libgfortran 5.3.0-6 (win-64): GPL, LGPL, FDL, custom (Non-SPDX)
 m2w64-gcc-libs 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gcc-libs-core 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gmp 6.1.0-2 (win-64): LGPL3 (Non-SPDX)
 m2w64-libwinpthread-git 5.0.0.4634.697f757-2 (win-64): MIT, BSD (Non-SPDX)
-micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL 
-msys2-conda-epoch 20160418-1 (win-64): None (Non-SPDX)
-ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause 
-ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause 
-ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause 
-ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause 
+micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL
+msys2-conda-epoch 20160418-1 (win-64): no license
+ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause
+ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause
+ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause
+ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause
 sysroot_linux-64 2.12-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 sysroot_linux-aarch64 2.17-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-tk 8.6.13-h194ca79_0 (linux-aarch64): TCL 
-tk 8.6.13-h1abcd95_1 (osx-64): TCL 
-tk 8.6.13-h5083fa2_1 (osx-arm64): TCL 
-tk 8.6.13-h5226925_1 (win-64): TCL 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain 
-ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary 
-vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft 
+tk 8.6.13-h194ca79_0 (linux-aarch64): TCL
+tk 8.6.13-h1abcd95_1 (osx-64): TCL
+tk 8.6.13-h5083fa2_1 (osx-arm64): TCL
+tk 8.6.13-h5226925_1 (win-64): TCL
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain
+ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary
+vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft
 win_inet_pton 1.1.0-pyhd8ed1ab_6 (noarch): PUBLIC-DOMAIN (Non-SPDX)
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h57fd34a_0 (osx-arm64): LGPL-2.1 and GPL-2.0 (Non-SPDX)

--- a/tests/snapshots/integration_tests__platform_env_restrictions_check.snap
+++ b/tests/snapshots/integration_tests__platform_env_restrictions_check.snap
@@ -5,27 +5,27 @@ expression: output
 
 ❌ The following dependencies are unsafe:
 
-_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause 
-bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6 
-ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC 
-ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only 
-libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only 
-libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause 
-libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later 
-libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause 
-nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0 
-python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause 
-readline 8.2-h8228510_1 (linux-64): GPL-3.0-only 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain 
+_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause
+bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6
+ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC
+ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only
+libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only
+libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause
+libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later
+libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause
+nodeenv 1.9.1-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+pycparser 2.22-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0
+python_abi 3.12-4_cp312 (linux-64): BSD-3-Clause
+readline 8.2-h8228510_1 (linux-64): GPL-3.0-only
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
-zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
+zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
 
 ❌ Unsafe licenses found! ❌
 There were 26 safe licenses and 21 unsafe licenses.

--- a/tests/snapshots/integration_tests__prefix_list.snap
+++ b/tests/snapshots/integration_tests__prefix_list.snap
@@ -2,52 +2,52 @@
 source: tests/integration_tests.rs
 expression: output
 ---
-asttokens 2.4.1-pyhd8ed1ab_0 (noarch): Apache-2.0 
-bzip2 1.0.8-h99b78c6_7 (osx-arm64): bzip2-1.0.6 
-ca-certificates 2024.8.30-hf0a4a13_0 (osx-arm64): ISC 
-decorator 5.1.1-pyhd8ed1ab_0 (noarch): BSD-2-Clause 
-exceptiongroup 1.2.2-pyhd8ed1ab_0 (noarch): MIT and PSF-2.0 
-executing 2.1.0-pyhd8ed1ab_0 (noarch): MIT 
-ipython 8.28.0-pyh707e725_0 (noarch): BSD-3-Clause 
-jedi 0.19.1-pyhd8ed1ab_0 (noarch): MIT 
-libblas 3.9.0-24_osxarm64_openblas (osx-arm64): BSD-3-Clause 
-libcblas 3.9.0-24_osxarm64_openblas (osx-arm64): BSD-3-Clause 
-libcxx 19.1.2-ha82da77_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-libexpat 2.6.3-hf9b8971_0 (osx-arm64): MIT 
-libffi 3.4.2-h3422bc3_5 (osx-arm64): MIT 
-libgfortran 5.0.0-13_2_0_hd922786_3 (osx-arm64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 13.2.0-hf226fd6_3 (osx-arm64): GPL-3.0-only WITH GCC-exception-3.1 
-liblapack 3.9.0-24_osxarm64_openblas (osx-arm64): BSD-3-Clause 
-libmpdec 4.0.0-h99b78c6_0 (osx-arm64): BSD-2-Clause 
-libopenblas 0.3.27-openmp_h517c56d_1 (osx-arm64): BSD-3-Clause 
-libsqlite 3.46.1-hc14010f_0 (osx-arm64): Unlicense 
-libzlib 1.3.1-h8359307_2 (osx-arm64): Zlib 
-llvm-openmp 19.1.2-hb52a8e5_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-matplotlib-inline 0.1.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-multipledispatch 0.6.0-pyhd8ed1ab_1 (noarch): BSD-3-Clause 
-ncurses 6.5-h7bae524_1 (osx-arm64): X11 AND BSD-3-Clause 
-numpy 2.1.2-py313hab0c69d_0 (osx-arm64): BSD-3-Clause 
-openssl 3.3.2-h8359307_0 (osx-arm64): Apache-2.0 
-pandas 2.2.3-py313h47b39a6_1 (osx-arm64): BSD-3-Clause 
-parso 0.8.4-pyhd8ed1ab_0 (noarch): MIT 
-pexpect 4.9.0-pyhd8ed1ab_0 (noarch): ISC 
-pickleshare 0.7.5-py_1003 (noarch): MIT 
-pip 24.2-pyh145f28c_1 (noarch): MIT 
-prompt-toolkit 3.0.48-pyha770c72_0 (noarch): BSD-3-Clause 
-ptyprocess 0.7.0-pyhd3deb0d_0 (noarch): ISC 
-pure_eval 0.2.3-pyhd8ed1ab_0 (noarch): MIT 
-pygments 2.18.0-pyhd8ed1ab_0 (noarch): BSD-2-Clause 
-python 3.13.0-h206b6c5_100_cp313 (osx-arm64): Python-2.0 
-python-dateutil 2.9.0-pyhd8ed1ab_0 (noarch): Apache-2.0 
-python-tzdata 2024.2-pyhd8ed1ab_0 (noarch): Apache-2.0 
-python_abi 3.13-5_cp313 (osx-arm64): BSD-3-Clause 
-pytz 2024.1-pyhd8ed1ab_0 (noarch): MIT 
-readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only 
-six 1.16.0-pyh6c4a22f_0 (noarch): MIT 
-stack_data 0.6.2-pyhd8ed1ab_0 (noarch): MIT 
-tk 8.6.13-h5083fa2_1 (osx-arm64): TCL 
-traitlets 5.14.3-pyhd8ed1ab_0 (noarch): BSD-3-Clause 
-typing_extensions 4.12.2-pyha770c72_0 (noarch): PSF-2.0 
-tzdata 2024b-hc8b5060_0 (noarch): LicenseRef-Public-Domain 
-wcwidth 0.2.13-pyhd8ed1ab_0 (noarch): MIT 
+asttokens 2.4.1-pyhd8ed1ab_0 (noarch): Apache-2.0
+bzip2 1.0.8-h99b78c6_7 (osx-arm64): bzip2-1.0.6
+ca-certificates 2024.8.30-hf0a4a13_0 (osx-arm64): ISC
+decorator 5.1.1-pyhd8ed1ab_0 (noarch): BSD-2-Clause
+exceptiongroup 1.2.2-pyhd8ed1ab_0 (noarch): MIT and PSF-2.0
+executing 2.1.0-pyhd8ed1ab_0 (noarch): MIT
+ipython 8.28.0-pyh707e725_0 (noarch): BSD-3-Clause
+jedi 0.19.1-pyhd8ed1ab_0 (noarch): MIT
+libblas 3.9.0-24_osxarm64_openblas (osx-arm64): BSD-3-Clause
+libcblas 3.9.0-24_osxarm64_openblas (osx-arm64): BSD-3-Clause
+libcxx 19.1.2-ha82da77_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+libexpat 2.6.3-hf9b8971_0 (osx-arm64): MIT
+libffi 3.4.2-h3422bc3_5 (osx-arm64): MIT
+libgfortran 5.0.0-13_2_0_hd922786_3 (osx-arm64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 13.2.0-hf226fd6_3 (osx-arm64): GPL-3.0-only WITH GCC-exception-3.1
+liblapack 3.9.0-24_osxarm64_openblas (osx-arm64): BSD-3-Clause
+libmpdec 4.0.0-h99b78c6_0 (osx-arm64): BSD-2-Clause
+libopenblas 0.3.27-openmp_h517c56d_1 (osx-arm64): BSD-3-Clause
+libsqlite 3.46.1-hc14010f_0 (osx-arm64): Unlicense
+libzlib 1.3.1-h8359307_2 (osx-arm64): Zlib
+llvm-openmp 19.1.2-hb52a8e5_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+matplotlib-inline 0.1.7-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+multipledispatch 0.6.0-pyhd8ed1ab_1 (noarch): BSD-3-Clause
+ncurses 6.5-h7bae524_1 (osx-arm64): X11 AND BSD-3-Clause
+numpy 2.1.2-py313hab0c69d_0 (osx-arm64): BSD-3-Clause
+openssl 3.3.2-h8359307_0 (osx-arm64): Apache-2.0
+pandas 2.2.3-py313h47b39a6_1 (osx-arm64): BSD-3-Clause
+parso 0.8.4-pyhd8ed1ab_0 (noarch): MIT
+pexpect 4.9.0-pyhd8ed1ab_0 (noarch): ISC
+pickleshare 0.7.5-py_1003 (noarch): MIT
+pip 24.2-pyh145f28c_1 (noarch): MIT
+prompt-toolkit 3.0.48-pyha770c72_0 (noarch): BSD-3-Clause
+ptyprocess 0.7.0-pyhd3deb0d_0 (noarch): ISC
+pure_eval 0.2.3-pyhd8ed1ab_0 (noarch): MIT
+pygments 2.18.0-pyhd8ed1ab_0 (noarch): BSD-2-Clause
+python 3.13.0-h206b6c5_100_cp313 (osx-arm64): Python-2.0
+python-dateutil 2.9.0-pyhd8ed1ab_0 (noarch): Apache-2.0
+python-tzdata 2024.2-pyhd8ed1ab_0 (noarch): Apache-2.0
+python_abi 3.13-5_cp313 (osx-arm64): BSD-3-Clause
+pytz 2024.1-pyhd8ed1ab_0 (noarch): MIT
+readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only
+six 1.16.0-pyh6c4a22f_0 (noarch): MIT
+stack_data 0.6.2-pyhd8ed1ab_0 (noarch): MIT
+tk 8.6.13-h5083fa2_1 (osx-arm64): TCL
+traitlets 5.14.3-pyhd8ed1ab_0 (noarch): BSD-3-Clause
+typing_extensions 4.12.2-pyha770c72_0 (noarch): PSF-2.0
+tzdata 2024b-hc8b5060_0 (noarch): LicenseRef-Public-Domain
+wcwidth 0.2.13-pyhd8ed1ab_0 (noarch): MIT
 xz 5.2.6-h57fd34a_0 (osx-arm64): LGPL-2.1 and GPL-2.0 (Non-SPDX)

--- a/tests/snapshots/integration_tests__pypi_ignore_check.snap
+++ b/tests/snapshots/integration_tests__pypi_ignore_check.snap
@@ -5,22 +5,22 @@ expression: output
 
 ❌ The following dependencies are unsafe:
 
-_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause 
-bzip2 1.0.8-h4bc722e_7 (linux-64): bzip2-1.0.6 
-ca-certificates 2024.8.30-hbcca054_0 (linux-64): ISC 
-ld_impl_linux-64 2.43-h712a8e2_1 (linux-64): GPL-3.0-only 
-libgcc 14.1.0-h77fa898_1 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-h69a702a_1 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-h77fa898_1 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only 
-libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause 
-libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later 
-libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-ncurses 6.5-he02047a_1 (linux-64): X11 AND BSD-3-Clause 
-python 3.12.6-hc5c86c4_1_cpython (linux-64): Python-2.0 
-readline 8.2-h8228510_1 (linux-64): GPL-3.0-only 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tzdata 2024a-h8827d51_1 (noarch): LicenseRef-Public-Domain 
+_openmp_mutex 4.5-2_gnu (linux-64): BSD-3-Clause
+bzip2 1.0.8-h4bc722e_7 (linux-64): bzip2-1.0.6
+ca-certificates 2024.8.30-hbcca054_0 (linux-64): ISC
+ld_impl_linux-64 2.43-h712a8e2_1 (linux-64): GPL-3.0-only
+libgcc 14.1.0-h77fa898_1 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-h69a702a_1 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-h77fa898_1 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only
+libuuid 2.38.1-h0b41bf4_0 (linux-64): BSD-3-Clause
+libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later
+libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+ncurses 6.5-he02047a_1 (linux-64): X11 AND BSD-3-Clause
+python 3.12.6-hc5c86c4_1_cpython (linux-64): Python-2.0
+readline 8.2-h8228510_1 (linux-64): GPL-3.0-only
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tzdata 2024a-h8827d51_1 (noarch): LicenseRef-Public-Domain
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 
 ❌ Unsafe licenses found! ❌

--- a/tests/snapshots/integration_tests__safe_licenses_in_config_check.snap
+++ b/tests/snapshots/integration_tests__safe_licenses_in_config_check.snap
@@ -6,149 +6,149 @@ expression: output
 ❌ The following dependencies are unsafe:
 
 _sysroot_linux-aarch64_curr_repodata_hack 4-h57d6b7b_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only 
-binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only 
-binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only 
-binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only 
-bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6 
-bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6 
-bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6 
-bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6 
-bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6 
-ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC 
-ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC 
-ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC 
-ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC 
-ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC 
-certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC 
-frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only 
-frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only 
-frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only 
-frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only 
-frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only 
-gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
+binutils 2.40-h4852527_7 (linux-64): GPL-3.0-only
+binutils 2.40-hf1166c9_7 (linux-aarch64): GPL-3.0-only
+binutils_impl_linux-64 2.40-ha1999f0_7 (linux-64): GPL-3.0-only
+binutils_impl_linux-aarch64 2.40-hf54a868_7 (linux-aarch64): GPL-3.0-only
+bzip2 1.0.8-h10d778d_5 (osx-64): bzip2-1.0.6
+bzip2 1.0.8-h31becfc_5 (linux-aarch64): bzip2-1.0.6
+bzip2 1.0.8-h93a5062_5 (osx-arm64): bzip2-1.0.6
+bzip2 1.0.8-hcfcfb64_5 (win-64): bzip2-1.0.6
+bzip2 1.0.8-hd590300_5 (linux-64): bzip2-1.0.6
+ca-certificates 2024.6.2-h56e8100_0 (win-64): ISC
+ca-certificates 2024.6.2-h8857fd0_0 (osx-64): ISC
+ca-certificates 2024.6.2-hbcca054_0 (linux-64): ISC
+ca-certificates 2024.6.2-hcefe29a_0 (linux-aarch64): ISC
+ca-certificates 2024.6.2-hf0a4a13_0 (osx-arm64): ISC
+certifi 2024.6.2-pyhd8ed1ab_0 (noarch): ISC
+frozendict 2.4.4-py312h396f95a_0 (linux-aarch64): LGPL-3.0-only
+frozendict 2.4.4-py312h4389bb4_0 (win-64): LGPL-3.0-only
+frozendict 2.4.4-py312h7e5086c_0 (osx-arm64): LGPL-3.0-only
+frozendict 2.4.4-py312h9a8786e_0 (linux-64): LGPL-3.0-only
+frozendict 2.4.4-py312hbd25219_0 (osx-64): LGPL-3.0-only
+gcc_impl_linux-64 12.3.0-h58ffeeb_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gcc_impl_linux-aarch64 12.3.0-h3d98823_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-64 12.3.0-h8f2110c_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gfortran_impl_linux-aarch64 12.3.0-h97ebfd2_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-64 12.3.0-h2a574ab_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+gxx_impl_linux-aarch64 12.3.0-hba91e99_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
 kernel-headers_linux-64 2.6.32-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 kernel-headers_linux-aarch64 4.18.0-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later 
-keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later 
-ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only 
-ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only 
-libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause 
-libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause 
-libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause 
-libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause 
-libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause 
-libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl 
-libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl 
-libcurl 8.8.0-hca28451_1 (linux-64): curl 
-libcurl 8.8.0-hd5e4a3a_1 (win-64): curl 
-libcurl 8.8.0-hf9fcc65_1 (osx-64): curl 
-libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception 
-libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception 
-libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause 
-libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause 
-libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause 
-libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause 
-libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause 
-libev 4.33-hd590300_2 (linux-64): BSD-2-Clause 
-libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later 
-libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later 
-libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only 
-libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only 
-libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only 
-libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only 
-libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only 
-libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later 
-libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later 
-libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only 
-libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only 
-libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1 
-libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1 
-libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later 
-libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later 
-libzlib 1.3.1-h2466b09_1 (win-64): Zlib 
-libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-libzlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
-lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause 
-lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause 
-lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause 
-lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause 
-lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause 
-lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later 
-lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later 
-lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later 
-lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later 
-lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later 
+keyutils 1.6.1-h166bdaf_0 (linux-64): LGPL-2.1-or-later
+keyutils 1.6.1-h4e544f5_0 (linux-aarch64): LGPL-2.1-or-later
+ld_impl_linux-64 2.40-hf3520f5_7 (linux-64): GPL-3.0-only
+ld_impl_linux-aarch64 2.40-h9fc2d93_7 (linux-aarch64): GPL-3.0-only
+libarchive 3.7.4-h20e244c_0 (osx-64): BSD-2-Clause
+libarchive 3.7.4-h2c0effa_0 (linux-aarch64): BSD-2-Clause
+libarchive 3.7.4-h83d404f_0 (osx-arm64): BSD-2-Clause
+libarchive 3.7.4-haf234dc_0 (win-64): BSD-2-Clause
+libarchive 3.7.4-hfca40fe_0 (linux-64): BSD-2-Clause
+libcurl 8.8.0-h4e8248e_1 (linux-aarch64): curl
+libcurl 8.8.0-h7b6f9a7_1 (osx-arm64): curl
+libcurl 8.8.0-hca28451_1 (linux-64): curl
+libcurl 8.8.0-hd5e4a3a_1 (win-64): curl
+libcurl 8.8.0-hf9fcc65_1 (osx-64): curl
+libcxx 17.0.6-h5f092b4_0 (osx-arm64): Apache-2.0 WITH LLVM-exception
+libcxx 17.0.6-h88467a6_0 (osx-64): Apache-2.0 WITH LLVM-exception
+libedit 3.1.20191231-h0678c8f_2 (osx-64): BSD-2-Clause
+libedit 3.1.20191231-hc8eb9b7_2 (osx-arm64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-64): BSD-2-Clause
+libedit 3.1.20191231-he28a2e2_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h10d778d_2 (osx-64): BSD-2-Clause
+libev 4.33-h31becfc_2 (linux-aarch64): BSD-2-Clause
+libev 4.33-h93a5062_2 (osx-arm64): BSD-2-Clause
+libev 4.33-hd590300_2 (linux-64): BSD-2-Clause
+libgcc-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgcc-ng 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-h9420597_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libgfortran5 14.1.0-hc5f4f2c_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libglib 2.80.2-h59d46d9_1 (osx-arm64): LGPL-2.1-or-later
+libglib 2.80.2-h7025463_1 (win-64): LGPL-2.1-or-later
+libgomp 14.1.0-h77fa898_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libgomp 14.1.0-he277a41_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libiconv 1.17-h0d3ecfb_2 (osx-arm64): LGPL-2.1-only
+libiconv 1.17-h31becfc_2 (linux-aarch64): LGPL-2.1-only
+libiconv 1.17-hcfcfb64_2 (win-64): LGPL-2.1-only
+libiconv 1.17-hd590300_2 (linux-64): LGPL-2.1-only
+libiconv 1.17-hd75f5a5_2 (osx-64): LGPL-2.1-only
+libintl 0.22.5-h5728263_2 (win-64): LGPL-2.1-or-later
+libintl 0.22.5-h8fbad5d_2 (osx-arm64): LGPL-2.1-or-later
+libnsl 2.0.1-h31becfc_0 (linux-aarch64): LGPL-2.1-only
+libnsl 2.0.1-hd590300_0 (linux-64): LGPL-2.1-only
+libsanitizer 12.3.0-h57e2e72_13 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libsanitizer 12.3.0-hb8811af_13 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-64 12.3.0-h6b66f73_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-devel_linux-aarch64 12.3.0-h6144e03_113 (noarch): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-h3f4de04_0 (linux-aarch64): GPL-3.0-only WITH GCC-exception-3.1
+libstdcxx-ng 14.1.0-hc0a3c3a_0 (linux-64): GPL-3.0-only WITH GCC-exception-3.1
+libxcrypt 4.4.36-h31becfc_1 (linux-aarch64): LGPL-2.1-or-later
+libxcrypt 4.4.36-hd590300_1 (linux-64): LGPL-2.1-or-later
+libzlib 1.3.1-h2466b09_1 (win-64): Zlib
+libzlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+libzlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+libzlib 1.3.1-h87427d6_1 (osx-64): Zlib
+libzlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
+lz4-c 1.9.4-hb7217d7_0 (osx-arm64): BSD-2-Clause
+lz4-c 1.9.4-hcb278e6_0 (linux-64): BSD-2-Clause
+lz4-c 1.9.4-hcfcfb64_0 (win-64): BSD-2-Clause
+lz4-c 1.9.4-hd600fc2_0 (linux-aarch64): BSD-2-Clause
+lz4-c 1.9.4-hf0c8a7f_0 (osx-64): BSD-2-Clause
+lzo 2.10-h10d778d_1001 (osx-64): GPL-2.0-or-later
+lzo 2.10-h31becfc_1001 (linux-aarch64): GPL-2.0-or-later
+lzo 2.10-h93a5062_1001 (osx-arm64): GPL-2.0-or-later
+lzo 2.10-hcfcfb64_1001 (win-64): GPL-2.0-or-later
+lzo 2.10-hd590300_1001 (linux-64): GPL-2.0-or-later
 m2w64-gcc-libgfortran 5.3.0-6 (win-64): GPL, LGPL, FDL, custom (Non-SPDX)
 m2w64-gcc-libs 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gcc-libs-core 5.3.0-7 (win-64): GPL3+, partial:GCCRLE, partial:LGPL2+ (Non-SPDX)
 m2w64-gmp 6.1.0-2 (win-64): LGPL3 (Non-SPDX)
 m2w64-libwinpthread-git 5.0.0.4634.697f757-2 (win-64): MIT, BSD (Non-SPDX)
-micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL 
-micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL 
-msys2-conda-epoch 20160418-1 (win-64): None (Non-SPDX)
-ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause 
-ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause 
-ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause 
-ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause 
-pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later 
-pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later 
-pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later 
-pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later 
-pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later 
-python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0 
-python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0 
-python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0 
-python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0 
-python 3.12.4-h889d299_0_cpython (win-64): Python-2.0 
-readline 8.2-h8228510_1 (linux-64): GPL-3.0-only 
-readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only 
-readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only 
-readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only 
+micromamba 1.5.8-0 (linux-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (linux-aarch64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (osx-arm64): BSD-3-Clause AND MIT AND OpenSSL
+micromamba 1.5.8-0 (win-64): BSD-3-Clause AND MIT AND OpenSSL
+msys2-conda-epoch 20160418-1 (win-64): no license
+ncurses 6.5-h0425590_0 (linux-aarch64): X11 AND BSD-3-Clause
+ncurses 6.5-h5846eda_0 (osx-64): X11 AND BSD-3-Clause
+ncurses 6.5-h59595ed_0 (linux-64): X11 AND BSD-3-Clause
+ncurses 6.5-hb89a1cb_0 (osx-arm64): X11 AND BSD-3-Clause
+pkg-config 0.29.2-h2bf4dc2_1008 (win-64): GPL-2.0-or-later
+pkg-config 0.29.2-h36c2ea0_1008 (linux-64): GPL-2.0-or-later
+pkg-config 0.29.2-ha3d46e9_1008 (osx-64): GPL-2.0-or-later
+pkg-config 0.29.2-hab62308_1008 (osx-arm64): GPL-2.0-or-later
+pkg-config 0.29.2-hb9de7d4_1008 (linux-aarch64): GPL-2.0-or-later
+python 3.12.4-h194c7f8_0_cpython (linux-64): Python-2.0
+python 3.12.4-h30c5eda_0_cpython (osx-arm64): Python-2.0
+python 3.12.4-h37a9e06_0_cpython (osx-64): Python-2.0
+python 3.12.4-h829453d_0_cpython (linux-aarch64): Python-2.0
+python 3.12.4-h889d299_0_cpython (win-64): Python-2.0
+readline 8.2-h8228510_1 (linux-64): GPL-3.0-only
+readline 8.2-h8fc344f_1 (linux-aarch64): GPL-3.0-only
+readline 8.2-h92ec313_1 (osx-arm64): GPL-3.0-only
+readline 8.2-h9e318b2_1 (osx-64): GPL-3.0-only
 sysroot_linux-64 2.12-he073ed8_17 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
 sysroot_linux-aarch64 2.17-h5b4a56d_14 (noarch): LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0 (Non-SPDX)
-tk 8.6.13-h194ca79_0 (linux-aarch64): TCL 
-tk 8.6.13-h1abcd95_1 (osx-64): TCL 
-tk 8.6.13-h5083fa2_1 (osx-arm64): TCL 
-tk 8.6.13-h5226925_1 (win-64): TCL 
-tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL 
-tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain 
-ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary 
-vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft 
+tk 8.6.13-h194ca79_0 (linux-aarch64): TCL
+tk 8.6.13-h1abcd95_1 (osx-64): TCL
+tk 8.6.13-h5083fa2_1 (osx-arm64): TCL
+tk 8.6.13-h5226925_1 (win-64): TCL
+tk 8.6.13-noxft_h4845f30_101 (linux-64): TCL
+tzdata 2024a-h0c530f3_0 (noarch): LicenseRef-Public-Domain
+ucrt 10.0.22621.0-h57928b3_0 (win-64): LicenseRef-Proprietary
+vc14_runtime 14.40.33810-ha82c5b3_20 (win-64): LicenseRef-ProprietaryMicrosoft
 win_inet_pton 1.1.0-pyhd8ed1ab_6 (noarch): PUBLIC-DOMAIN (Non-SPDX)
 xz 5.2.6-h166bdaf_0 (linux-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h57fd34a_0 (osx-arm64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h775f41a_0 (osx-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h8d14728_0 (win-64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
 xz 5.2.6-h9cdd2b7_0 (linux-aarch64): LGPL-2.1 and GPL-2.0 (Non-SPDX)
-zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib 
-zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib 
-zlib 1.3.1-h87427d6_1 (osx-64): Zlib 
-zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib 
+zlib 1.3.1-h4ab18f5_1 (linux-64): Zlib
+zlib 1.3.1-h68df207_1 (linux-aarch64): Zlib
+zlib 1.3.1-h87427d6_1 (osx-64): Zlib
+zlib 1.3.1-hfb2fe0b_1 (osx-arm64): Zlib
 
 ❌ Unsafe licenses found! ❌
 There were 255 safe licenses and 144 unsafe licenses.


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->
The upstream API of `PartialSourceMetadata` for source packages has changed again.
It now includes information about the license of source packages.
This enables us to build `LicenseInfos` from source packages, which in turn enables license checking for `pixi` lockfiles that contain source package entries without ignoring them.

# Changes

<!-- What changes have been performed? -->
This PR bumps all upstream dependencies to their newest versions and adds functionality to create `LicenseInfos` from source package entries with partial metadata.