### PR TITLE
Avoid autoupdates for test pixi lockfiles

### DIFF
--- a/tests/pixi-build/local-pkg/pixi.toml
+++ b/tests/pixi-build/local-pkg/pixi.toml
@@ -8,6 +8,6 @@ backend = { name = "pixi-build-cmake", version = "==0.3.10" }
 [package.run-dependencies]
 curl = "==8.17.0"
 
-# Avoid GitHub tooling trying to update this pixi.toml
+# Avoid tooling trying to autoupdate this pixi.toml
 [tool.update]
 autoupdate-schedule = "never"

--- a/tests/pixi-build/local-pkg/pixi.toml
+++ b/tests/pixi-build/local-pkg/pixi.toml
@@ -7,3 +7,7 @@ backend = { name = "pixi-build-cmake", version = "==0.3.10" }
 
 [package.run-dependencies]
 curl = "==8.17.0"
+
+# Avoid GitHub tooling trying to update this pixi.toml
+[tool.update]
+autoupdate-schedule = "never"

--- a/tests/test_default_use_case/pixi.toml
+++ b/tests/test_default_use_case/pixi.toml
@@ -43,6 +43,6 @@ lint = { features = ["lint"], no-default-feature = true }
 [tool.conda-deny]
 license-allowlist = "license_allowlist.toml"
 
-# Avoid GitHub tooling trying to update this pixi.toml
+# Avoid tooling trying to autoupdate this pixi.toml
 [tool.update]
 autoupdate-schedule = "never"

--- a/tests/test_default_use_case/pixi.toml
+++ b/tests/test_default_use_case/pixi.toml
@@ -42,3 +42,7 @@ lint = { features = ["lint"], no-default-feature = true }
 
 [tool.conda-deny]
 license-allowlist = "license_allowlist.toml"
+
+# Avoid GitHub tooling trying to update this pixi.toml
+[tool.update]
+autoupdate-schedule = "never"

--- a/tests/test_ignored_source_package/pixi.toml
+++ b/tests/test_ignored_source_package/pixi.toml
@@ -1,3 +1,7 @@
 [tool.conda-deny]
 lockfile = "tests/test_ignored_source_package/pixi.lock"
 safe-licenses = ["MIT"]
+
+# Avoid GitHub tooling trying to update this pixi.toml
+[tool.update]
+autoupdate-schedule = "never"

--- a/tests/test_ignored_source_package/pixi.toml
+++ b/tests/test_ignored_source_package/pixi.toml
@@ -2,6 +2,6 @@
 lockfile = "tests/test_ignored_source_package/pixi.lock"
 safe-licenses = ["MIT"]
 
-# Avoid GitHub tooling trying to update this pixi.toml
+# Avoid tooling trying to autoupdate this pixi.toml
 [tool.update]
 autoupdate-schedule = "never"

--- a/tests/test_lockfile_pattern/pixi.toml
+++ b/tests/test_lockfile_pattern/pixi.toml
@@ -7,6 +7,6 @@ platforms = ["linux-64"]
 license-allowlist = "$TEST_FOLDER/license_allowlist.toml"
 lockfile = "$TEST_FOLDER//**/*.lock"
 
-# Avoid GitHub tooling trying to update this pixi.toml
+# Avoid tooling trying to autoupdate this pixi.toml
 [tool.update]
 autoupdate-schedule = "never"

--- a/tests/test_lockfile_pattern/pixi.toml
+++ b/tests/test_lockfile_pattern/pixi.toml
@@ -6,3 +6,7 @@ platforms = ["linux-64"]
 [tool.conda-deny]
 license-allowlist = "$TEST_FOLDER/license_allowlist.toml"
 lockfile = "$TEST_FOLDER//**/*.lock"
+
+# Avoid GitHub tooling trying to update this pixi.toml
+[tool.update]
+autoupdate-schedule = "never"

--- a/tests/test_lockfile_pattern/subdir/another_subdir/pixi.toml
+++ b/tests/test_lockfile_pattern/subdir/another_subdir/pixi.toml
@@ -5,3 +5,7 @@ platforms = ["linux-64"]
 
 [dependencies]
 vhs = "*"
+
+# Avoid GitHub tooling trying to update this pixi.toml
+[tool.update]
+autoupdate-schedule = "never"

--- a/tests/test_lockfile_pattern/subdir/another_subdir/pixi.toml
+++ b/tests/test_lockfile_pattern/subdir/another_subdir/pixi.toml
@@ -6,6 +6,6 @@ platforms = ["linux-64"]
 [dependencies]
 vhs = "*"
 
-# Avoid GitHub tooling trying to update this pixi.toml
+# Avoid tooling trying to autoupdate this pixi.toml
 [tool.update]
 autoupdate-schedule = "never"

--- a/tests/test_lockfile_pattern/subdir/pixi.toml
+++ b/tests/test_lockfile_pattern/subdir/pixi.toml
@@ -8,3 +8,7 @@ rust = "==1.77.2"
 openssl = "3.*"
 pkg-config = "*"
 k9s = "*"
+
+# Avoid GitHub tooling trying to update this pixi.toml
+[tool.update]
+autoupdate-schedule = "never"

--- a/tests/test_lockfile_pattern/subdir/pixi.toml
+++ b/tests/test_lockfile_pattern/subdir/pixi.toml
@@ -9,6 +9,6 @@ openssl = "3.*"
 pkg-config = "*"
 k9s = "*"
 
-# Avoid GitHub tooling trying to update this pixi.toml
+# Avoid tooling trying to autoupdate this pixi.toml
 [tool.update]
 autoupdate-schedule = "never"

--- a/tests/test_source_package_with_record/pixi.toml
+++ b/tests/test_source_package_with_record/pixi.toml
@@ -1,3 +1,7 @@
 [tool.conda-deny]
 lockfile = "tests/test_source_package_with_record/pixi.lock"
 safe-licenses = ["MIT"]
+
+# Avoid GitHub tooling trying to update this pixi.toml
+[tool.update]
+autoupdate-schedule = "never"

--- a/tests/test_source_package_with_record/pixi.toml
+++ b/tests/test_source_package_with_record/pixi.toml
@@ -2,6 +2,6 @@
 lockfile = "tests/test_source_package_with_record/pixi.lock"
 safe-licenses = ["MIT"]
 
-# Avoid GitHub tooling trying to update this pixi.toml
+# Avoid tooling trying to autoupdate this pixi.toml
 [tool.update]
 autoupdate-schedule = "never"


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->
Prior to this PR, `quant-ranger` tried to auto-update all existing `pixi.lock` files.

# Changes

<!-- What changes have been performed? -->
This PR excludes them from autoupdates in the future.